### PR TITLE
fix: Corregir problema de compatibilidad Docker con heredoc en CapRover

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,55 +41,7 @@ ENV PORT=80
 RUN mkdir -p /etc/nginx/templates
 
 # Configuración de Nginx optimizada para CapRover
-COPY <<EOF /etc/nginx/templates/default.conf.template
-server {
-    listen \${PORT};
-    server_name _;
-    root /usr/share/nginx/html;
-    index index.html;
-    
-    # Configuración para SPA
-    location / {
-        try_files \$uri \$uri/ /index.html;
-    }
-    
-    # Configuración de cache para assets estáticos
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)\$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
-        add_header Vary "Accept-Encoding";
-    }
-    
-    # Configuración de seguridad mejorada
-    add_header X-Frame-Options "SAMEORIGIN" always;
-    add_header X-Content-Type-Options "nosniff" always;
-    add_header X-XSS-Protection "1; mode=block" always;
-    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
-    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://kit.fontawesome.com https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://ka-f.fontawesome.com; font-src 'self' https://fonts.gstatic.com https://ka-f.fontawesome.com; img-src 'self' data: https:; connect-src 'self';" always;
-    
-    # Compresión gzip
-    gzip on;
-    gzip_vary on;
-    gzip_min_length 1024;
-    gzip_proxied any;
-    gzip_comp_level 6;
-    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
-    
-    # Health check endpoint para CapRover
-    location /health {
-        access_log off;
-        return 200 "healthy\n";
-        add_header Content-Type text/plain;
-    }
-    
-    # Endpoint de status para monitoreo
-    location /status {
-        access_log off;
-        return 200 '{"status":"ok","service":"sgsolucionesing","timestamp":"\$time_iso8601"}';
-        add_header Content-Type application/json;
-    }
-}
-EOF
+COPY nginx.conf.template /etc/nginx/templates/default.conf.template
 
 # Copiar archivos construidos desde la etapa de build
 COPY --from=builder /app/dist /usr/share/nginx/html

--- a/docs/despliegue-docker-caprover.md
+++ b/docs/despliegue-docker-caprover.md
@@ -22,10 +22,31 @@ El proyecto incluye un Dockerfile multi-stage que:
 - **Etapa 1 (Builder)**: Construye la aplicación Astro
 - **Etapa 2 (Producción)**: Sirve los archivos estáticos con Nginx
 
+### captain-definition
+Archivo requerido por CapRover que especifica la configuración de despliegue:
+
+```json
+{
+  "schemaVersion": 2,
+  "dockerfilePath": "./Dockerfile"
+}
+```
+
+### nginx.conf.template
+Archivo de configuración de Nginx que se utiliza en el contenedor de producción. Este archivo contiene:
+- Configuración para Single Page Application (SPA)
+- Headers de seguridad (CSP, X-Frame-Options, etc.)
+- Configuración de cache para assets estáticos
+- Compresión gzip
+- Endpoints de health check (`/health` y `/status`)
+
+**Nota:** Este archivo se creó para resolver problemas de compatibilidad con versiones de Docker que no soportan heredoc (<<EOF) en comandos COPY.
+
 ### Archivos de Configuración Incluidos
 - `Dockerfile`: Configuración de contenedor optimizada
 - `.dockerignore`: Excluye archivos innecesarios del contexto
 - `captain-definition`: Configuración para CapRover
+- `nginx.conf.template`: Configuración de Nginx para producción
 - `docker-compose.yml`: Para testing local
 
 ## Despliegue Local con Docker

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,0 +1,47 @@
+server {
+    listen ${PORT};
+    server_name _;
+    root /usr/share/nginx/html;
+    index index.html;
+    
+    # Configuración para SPA
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+    
+    # Configuración de cache para assets estáticos
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+        add_header Vary "Accept-Encoding";
+    }
+    
+    # Configuración de seguridad mejorada
+    add_header X-Frame-Options "SAMEORIGIN" always;
+    add_header X-Content-Type-Options "nosniff" always;
+    add_header X-XSS-Protection "1; mode=block" always;
+    add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+    add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://kit.fontawesome.com https://fonts.googleapis.com; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://ka-f.fontawesome.com; font-src 'self' https://fonts.gstatic.com https://ka-f.fontawesome.com; img-src 'self' data: https:; connect-src 'self';" always;
+    
+    # Compresión gzip
+    gzip on;
+    gzip_vary on;
+    gzip_min_length 1024;
+    gzip_proxied any;
+    gzip_comp_level 6;
+    gzip_types text/plain text/css text/xml text/javascript application/javascript application/xml+rss application/json;
+    
+    # Health check endpoint para CapRover
+    location /health {
+        access_log off;
+        return 200 "healthy\n";
+        add_header Content-Type text/plain;
+    }
+    
+    # Endpoint de status para monitoreo
+    location /status {
+        access_log off;
+        return 200 '{"status":"ok","service":"sgsolucionesing","timestamp":"$time_iso8601"}';
+        add_header Content-Type application/json;
+    }
+}


### PR DESCRIPTION
- Crear archivo nginx.conf.template separado para configuración de Nginx
- Reemplazar COPY heredoc (<<EOF) con COPY de archivo en Dockerfile
- Actualizar .dockerignore para incluir nginx.conf.template
- Verificar funcionamiento correcto de endpoints /health y /status
- Actualizar documentación con información sobre nginx.conf.template

Esto resuelve el error 'COPY failed: no source files were specified' en CapRover