### PR TITLE
fix(deploy): el contenedor no arranca en Dokploy por ${PORT} en nginx

### DIFF
--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,12 +1,17 @@
 server {
-    listen ${PORT};
+    # Puerto fijo 80: coincide con EXPOSE y el HEALTHCHECK del Dockerfile.
+    # Antes era ${PORT}, variable que inyectaba CapRover pero que Dokploy no
+    # define; al quedar vacía, nginx abortaba con "host not found in ${PORT}".
+    listen 80;
     server_name _;
     root /usr/share/nginx/html;
     index index.html;
-    
-    # Configuración para SPA
+
+    # Sitio estático (Astro SSG): las rutas inexistentes deben dar 404.
+    # El fallback a /index.html hacía que cualquier URL respondiera 200 con
+    # el home, generando contenido duplicado para los buscadores.
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri $uri/ =404;
     }
     
     # Configuración de cache para assets estáticos


### PR DESCRIPTION
## Por qué el sitio sigue mostrando el diseño viejo

`main` tiene todo el rediseño (PRs #11 y #12 mergeados) y **Dokploy sí está clonando el commit correcto** (`8103772`, branch `main`) y construyendo la imagen. El problema es que **el contenedor nuevo muere al arrancar**:

```
nginx: [emerg] host not found in "${PORT}" of the "listen" directive
      in /etc/nginx/conf.d/default.conf:2
```

Docker Swarm marca el task como `Failed — task: non-zero exit (1)` y **mantiene corriendo el contenedor anterior**, que sirve el build viejo. Por eso el deploy "parece" exitoso pero la web no cambia.

**Causa:** `nginx.conf.template` usa `listen ${PORT};`. `PORT` es una variable que **inyectaba CapRover** (el repo venía de ahí), pero **Dokploy no la define**. El entrypoint de la imagen nginx corre `envsubst` sobre el template, `${PORT}` queda vacío → `listen ;` → nginx aborta.

## Cambios

1. **`listen ${PORT}` → `listen 80`** — coincide con el `EXPOSE 80` y el `HEALTHCHECK` (`curl http://localhost/health`) que ya tiene el Dockerfile. Elimina la dependencia de CapRover.

2. **`try_files $uri $uri/ /index.html` → `try_files $uri $uri/ =404`** — es un sitio **estático** (Astro SSG), no una SPA. Con el fallback, *cualquier* URL inexistente devolvía **200 con el home**: `/robots.txt` respondía el HTML del home, y los buscadores veían infinitas URLs válidas con contenido duplicado. (Este bug además enmascaró el diagnóstico.)

## Verificación

Validado en el propio servidor, en un contenedor descartable y **sin `PORT` en el entorno**:

```
nginx: the configuration file /etc/nginx/nginx.conf syntax is ok
nginx: configuration file /etc/nginx/nginx.conf test is successful
```

## Al mergear

Dokploy redespliega, el contenedor **ahora sí arranca** y queda sirviendo el rediseño. Se resuelve de paso un 404 que aparecía en los logs (`construccion-tableros-medida-miobox.jpg`): el archivo existe en `main`, faltaba solo en el build viejo.

## Nota aparte
El repo todavía tiene config de **CapRover** (`captain-definition`, `deploy-caprover.sh`, `.caprover`, `docs/despliegue-docker-caprover.md`) aunque el despliegue real es **Dokploy**. Conviene limpiarlo para que no vuelva a confundir; no lo toqué en este PR para mantenerlo enfocado en el hotfix.