### PR TITLE
docs: actualiza documentación al rediseño Nocturne y elimina Splide

### DIFF
--- a/docs/contribucion.md
+++ b/docs/contribucion.md
@@ -94,13 +94,15 @@ Cuando hayas completado tu trabajo:
 ```html
 <button class="
   px-4 py-2 rounded-lg  /* Spacing y bordes */
-  bg-primary text-white  /* Colores */
+  bg-teal text-white  /* Colores (tokens Nocturne) */
   font-medium transition-colors  /* Tipografía y transiciones */
-  hover:bg-primary-dark focus:ring-2  /* Estados */
+  hover:bg-teal-600 focus:ring-2  /* Estados */
 ">
   Botón de Acción
 </button>
 ```
+
+Para componentes que ya siguen el sistema de diseño "Nocturne" (secciones de la home, páginas de proyectos), preferí las clases hechas a mano de `src/styles/nocturne.css` (`.btn-t`, `.btn-o`, `.sec`, etc.) en vez de reconstruirlas con utilidades de Tailwind.
 
 ### JavaScript
 
@@ -128,10 +130,11 @@ const validarFormulario = () => {
 
 Sigue estas pautas al crear nuevos archivos:
 
-- **Componentes**: Colócalos en `src/components/` con nombres descriptivos en PascalCase (ej. `ContactForm.astro`)
-- **Páginas**: Colócalas en `src/pages/` con nombres en kebab-case (ej. `casos-exito.astro`)
-- **Estilos**: Estilos específicos de componentes dentro del componente, estilos globales en `src/styles/`
+- **Componentes**: Colócalos en `src/components/` con nombres descriptivos en PascalCase (ej. `ContactForm.astro`); las secciones del sistema de diseño "Nocturne" viven en `src/components/nocturne/`
+- **Páginas**: Colócalas en `src/pages/` con nombres en kebab-case (ej. `contacto.astro`)
+- **Estilos**: Estilos específicos de componentes dentro del componente, estilos globales en `src/styles/nocturne.css`
 - **Assets**: Imágenes y otros recursos en `src/assets/` organizados por tipo
+- **Contenido**: Nuevos proyectos/casos de éxito como archivos MDX en `src/content/proyectos/`, respetando el schema de `src/content/config.ts`
 
 ## Optimización de Rendimiento
 
@@ -146,16 +149,15 @@ Asegúrate de que cada página incluya los metadatos necesarios para SEO:
 
 ```astro
 ---
-import Layout from '../layouts/Layout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 
 const title = "Título de la Página | S&G Soluciones de Ingeniería";
 const description = "Descripción clara y concisa para SEO";
-const keywords = "palabras, clave, relevantes";
 ---
 
-<Layout title={title} description={description} keywords={keywords}>
+<BaseLayout title={title} description={description}>
   <!-- Contenido de la página -->
-</Layout>
+</BaseLayout>
 ```
 
 ## Pruebas

--- a/docs/estructura-proyecto.md
+++ b/docs/estructura-proyecto.md
@@ -4,10 +4,14 @@ Este documento detalla la estructura del proyecto del sitio web de S&G Solucione
 
 ## Tecnologías Utilizadas
 
-- **Astro**: Framework principal para la construcción del sitio web
-- **Tailwind CSS**: Framework de CSS para estilos
-- **HTML**: Estructura básica de las páginas
-- **JavaScript**: Funcionalidades interactivas
+- **Astro 5**: Framework principal para la construcción del sitio web (SSG, sin SSR)
+- **Tailwind CSS 3**: Framework de CSS para estilos utilitarios
+- **astro-icon**: Iconos vía Iconify (`@iconify-json/mdi`)
+- **@astrojs/mdx**: Soporte MDX para el contenido de proyectos
+- **@astrojs/sitemap**: Generación automática de sitemap
+- **Zod**: Validación de esquema de las colecciones de contenido
+- **HTML**: Estructura semántica de las páginas
+- **JavaScript**: Vanilla, mínimo, solo donde es necesario (nav sticky, reveal on scroll, modal de galería)
 
 ## Estructura de Carpetas
 
@@ -16,23 +20,36 @@ Este documento detalla la estructura del proyecto del sitio web de S&G Solucione
 ├── docs/                # Documentación del proyecto
 │   ├── README.md        # Información general sobre la documentación
 │   ├── guia-de-uso.md   # Guía principal de uso del proyecto
-│   └── estructura-proyecto.md # Este documento
+│   ├── estructura-proyecto.md # Este documento
+│   ├── guia-desarrollo.md     # Directrices de desarrollo
+│   ├── contribucion.md        # Flujo de contribución
+│   ├── despliegue-dokploy.md  # Guía de despliegue en Dokploy
+│   └── seo-optimizacion.md    # Guía de SEO
 ├── public/              # Archivos estáticos accesibles públicamente
 │   └── favicon.svg      # Favicon del sitio
 ├── src/
-│   ├── assets/          # Imágenes, fuentes y otros recursos
-│   │   ├── astro.svg    # Logo de Astro (a reemplazar)
-│   │   └── background.svg # Imagen de fondo
-│   ├── components/      # Componentes reutilizables
-│   │   └── Welcome.astro # Componente principal de la página de inicio
-│   ├── layouts/         # Plantillas de diseño
-│   │   └── Layout.astro # Layout principal del sitio
-│   ├── pages/           # Páginas del sitio
-│   │   ├── index.astro  # Página principal
-│   │   ├── casos-exito.astro # Página de casos de éxito
-│   │   └── contacto.astro # Página de contacto
-│   └── styles/          # Estilos globales
-│       └── global.css   # Estilos globales con Tailwind
+│   ├── assets/          # Imágenes, fuentes y otros recursos (branding, images, icons)
+│   ├── components/
+│   │   └── nocturne/    # Componentes de sección del sistema de diseño "Nocturne"
+│   │       ├── Hero.astro
+│   │       ├── Servicios.astro
+│   │       ├── Casos.astro
+│   │       ├── Nosotros.astro
+│   │       ├── Testimonios.astro
+│   │       └── Contacto.astro
+│   ├── content/
+│   │   ├── config.ts    # Definición de la colección `proyectos` (schema Zod)
+│   │   └── proyectos/   # Entradas MDX (casos/proyectos)
+│   ├── layouts/
+│   │   └── BaseLayout.astro # Layout único del sitio (nav fijo, slot, footer)
+│   ├── pages/            # Páginas del sitio
+│   │   ├── index.astro           # Página principal
+│   │   ├── contacto.astro        # Página de contacto
+│   │   └── proyectos/
+│   │       ├── index.astro       # Listado de proyectos
+│   │       └── [slug].astro      # Detalle de proyecto (ruta dinámica)
+│   └── styles/           # Estilos globales
+│       └── nocturne.css  # Sistema de diseño "Nocturne" (tokens y clases con Tailwind)
 ├── astro.config.mjs     # Configuración de Astro
 ├── package.json         # Dependencias y scripts
 ├── tailwind.config.js   # Configuración de Tailwind CSS
@@ -43,82 +60,82 @@ Este documento detalla la estructura del proyecto del sitio web de S&G Solucione
 
 ### Layouts
 
-- **Layout.astro**: Plantilla principal que contiene la estructura HTML básica, metadatos SEO y enlaces a estilos y scripts. Todas las páginas utilizan este layout como base.
+- **BaseLayout.astro**: Único layout del sitio; lo usan todas las páginas (home, contacto, proyectos/*). Contiene la estructura HTML básica, metadatos SEO (`title`/`description` por props), la carga de fuentes (Barlow / Barlow Condensed), el nav fijo (`.nav`, con clase `.solid` al hacer scroll), el `<slot />` con el contenido de la página, el footer, y el script inline que gestiona el scroll y el reveal (`IntersectionObserver` sobre `.rv`).
 
-### Componentes
+### Componentes (`src/components/nocturne/`)
 
-- **Welcome.astro**: Componente principal que integra todos los componentes modulares y define estilos globales
-- **HeroSection.astro**: Sección hero con fondo animado y logo de la empresa
-- **StatsSection.astro**: Sección de estadísticas con contadores animados
-- **ServicesSection.astro**: Sección de servicios/unidades de negocio con iconos FontAwesome
-- **PlatformsSection.astro**: Sección de acceso multiplataforma con iconos de dispositivos
-- **AboutSection.astro**: Sección "Quiénes Somos" con información de la empresa
-- **SectorsSection.astro**: Sección de sectores de aplicación
-- **ProjectsSection.astro**: Biblioteca de proyectos con imágenes
-- **TestimonialsSection.astro**: Sección de testimonios con avatares personalizados
+- **Hero.astro**: Sección hero de la home
+- **Servicios.astro**: Sección de servicios/unidades de negocio
+- **Casos.astro**: Sección de proyectos/casos de éxito destacados
+- **Nosotros.astro**: Sección "Quiénes Somos" con información de la empresa
+- **Testimonios.astro**: Sección de testimonios
+- **Contacto.astro**: Sección/formulario de contacto
 
 ### Páginas
 
-- **index.astro**: Página principal que utiliza el componente Welcome.
-- **casos-exito.astro**: Página que muestra los proyectos exitosos de la empresa.
-- **contacto.astro**: Página con información de contacto y formulario.
+- **index.astro**: Página principal; compone `Hero`, `Servicios`, `Casos`, `Nosotros`, `Testimonios` y `Contacto` dentro de `BaseLayout`
+- **contacto.astro**: Página con información de contacto y formulario
+- **proyectos/index.astro**: Listado de proyectos, iterando la colección de contenido `proyectos`
+- **proyectos/[slug].astro**: Ruta dinámica que renderiza el detalle de un proyecto (MDX vía `<Content />` dentro de `.prose-n`) más una galería de imágenes con modal (navegación por teclado y swipe táctil)
+
+### Contenido
+
+- **src/content/config.ts**: Define la colección `proyectos` con schema Zod (`title`, `slug`, `sector`, `cliente`, `ubicacion`, `fecha`, `coverImage`, `resumen`, `kpis[]`, `tecnologias[]`, `tags[]`, `destacado`, `order`, `gallery[]`)
+- **src/content/proyectos/*.mdx**: Entradas de la colección; cada archivo es un proyecto/caso de éxito
 
 ### Estilos
 
-- **global.css**: Archivo de estilos globales que utiliza Tailwind CSS para definir clases y componentes reutilizables.
+- **nocturne.css**: Sistema de diseño "Nocturne", con tokens CSS (`--teal`, `--navy`, `--ink`, `--paper`, `--line`, `--muted`) y clases reutilizables (`.kick`, `.btn-t`/`.btn-o`, `.sec`, `.phead`, `.factbar`, `.prose-n`, entre otras). Se importa una única vez desde `BaseLayout.astro`.
 
 ## Guía de Estilos
 
 ### Colores Corporativos
 
-Los colores corporativos están definidos en el archivo `tailwind.config.mjs` y coinciden con el diseño original:
+Los colores corporativos están definidos como tokens CSS en `src/styles/nocturne.css` y expuestos también como colores de Tailwind en `tailwind.config.js`:
 
-- **Primary**: #2DD4BF (Teal/Turquesa principal)
-- **Secondary**: #1E3A8A (Azul secundario)
-- **Dark-blue**: #0F172A (Azul oscuro)
-- **Accent**: #FFD700 (Dorado para acentos)
-- **Dark**: #333333 (Gris oscuro)
-- **Light**: #F8FAFC (Gris claro del diseño original)
+- **teal**: `#00a79d` (color principal, con variantes `300`/`600`/`700`/`50`)
+- **navy**: `#122a49`
+- **ink**: `#0d1417` (con variante `2`: `#141d21`) — texto principal / fondo oscuro
+- **paper**: `#f4f6f6` (con variante `2`: `#eceff0`) — fondo claro
+- **line**: `#d9dedf` — bordes/divisores
+- **muted**: `#5b6567` — texto secundario
+
+No existe la paleta `primary`/`secondary`/`dark-blue`/`light-gray`; pertenecía al diseño anterior y fue reemplazada por completo.
 
 ### Tipografía
 
-- **Sans**: Inter, system-ui, sans-serif (Texto general)
-- **Heading**: Montserrat, sans-serif (Títulos y encabezados)
+- **body**: Barlow (texto general)
+- **cond**: Barlow Condensed (títulos, kickers y encabezados)
+
+Ambas se cargan desde Google Fonts en `BaseLayout.astro`.
 
 ## Componentes de UI Reutilizables
 
-Se han definido varios componentes de UI reutilizables en los estilos globales:
+Definidos en `src/styles/nocturne.css`:
 
 - **Botones**:
-  - `.btn-primary`: Botón principal con color teal (#2DD4BF)
-  - `.btn-outline`: Botón con borde y efectos hover
-  - Efectos hover con transformación scale(1.05)
-
-- **Estadísticas**:
-  - `.stats-counter`: Contadores con gradiente de colores primarios
-  - Animaciones de aparición con scroll
-
-- **Iconos de Servicios**:
-  - `.service-icon`: Iconos con gradiente y efectos hover
-  - Transformación y sombra en hover
-
-- **Efectos de Tarjetas**:
-  - `.card-hover`: Efectos de elevación y transformación
-  - `.section-divider`: Divisores de sección con gradiente
+  - `.btn-t`: Botón principal, fondo `teal`, con efecto hover (oscurece + eleva)
+  - `.btn-o`: Botón con borde (`outline`) y efecto hover
+- **Secciones**:
+  - `.sec`: Padding estándar de sección
+  - `.sec-head`: Encabezado de sección (título + lead)
+  - `.kick`: Kicker/eyebrow con línea decorativa antes del texto
+  - `.phead`: Bloque hero de cabecera para páginas internas (ej. listado/detalle de proyectos)
+  - `.factbar`: Barra de datos/estadísticas
+- **Contenido de proyecto**:
+  - `.prose-n`: Estilos de contenido MDX/prosa en el detalle de proyecto
+  - `.gallery` / `.gal-grid`: Grilla de imágenes de la galería
 
 ## Animaciones y Efectos
 
-### Animaciones de Fondo
-- **hero-animated-bg**: Gradiente animado en la sección hero
-- **animated-gradient**: Animación de movimiento de fondo
+### Reveal on Scroll
+- Clase `.rv`: elementos con esta clase reciben `.in` cuando entran en el viewport (vía `IntersectionObserver` en `BaseLayout.astro`), disparando su animación de aparición definida en CSS
 
-### Animaciones de Scroll
-- **fade-in-element**: Elementos que aparecen al hacer scroll
-- **pulse**: Animación de pulsación para elementos destacados
+### Nav sticky
+- `.nav` agrega `.solid` cuando el scroll supera 40px (ver script en `BaseLayout.astro`)
 
 ### Efectos Hover
-- Transformaciones scale() en botones e iconos
-- Cambios de opacidad y sombras
+- Transformaciones y cambios de color/sombra en botones (`.btn-t`, `.btn-o`) y otros elementos interactivos
 - Transiciones suaves con CSS transitions
 
 ## Cómo Contribuir
@@ -128,27 +145,26 @@ Se han definido varios componentes de UI reutilizables en los estilos globales:
 Para agregar una nueva página al sitio:
 
 1. Crea un nuevo archivo `.astro` en la carpeta `src/pages/`
-2. Importa el Layout principal:
+2. Importa el layout único:
    ```astro
    ---
-   import Layout from '../layouts/Layout.astro';
-   
+   import BaseLayout from '../layouts/BaseLayout.astro';
+
    // SEO metadata específico para esta página
    const title = "Título de la Página | S&G Soluciones de Ingeniería";
    const description = "Descripción de la página para SEO";
-   const keywords = "palabras, clave, relevantes";
    ---
-   
-   <Layout title={title} description={description} keywords={keywords}>
+
+   <BaseLayout title={title} description={description}>
      <!-- Contenido de la página -->
-   </Layout>
+   </BaseLayout>
    ```
 
 ### Agregar Nuevos Componentes
 
-Para crear un nuevo componente reutilizable:
+Para crear un nuevo componente reutilizable (por ejemplo, una nueva sección de la home):
 
-1. Crea un nuevo archivo `.astro` en la carpeta `src/components/`
+1. Crea un nuevo archivo `.astro` en `src/components/nocturne/` (o en `src/components/` si no es una sección del sistema Nocturne)
 2. Define la estructura del componente:
    ```astro
    ---
@@ -175,8 +191,8 @@ Para crear un nuevo componente reutilizable:
 
 Para modificar los estilos globales:
 
-1. Edita el archivo `src/styles/global.css` para cambios en los estilos base
-2. Para cambiar los colores corporativos o tipografía, modifica el archivo `tailwind.config.js`
+1. Edita el archivo `src/styles/nocturne.css` para cambios en tokens y clases del sistema de diseño
+2. Para cambiar los colores corporativos o tipografía expuestos a Tailwind, modifica `tailwind.config.js`
 
 ## Optimización para SEO
 
@@ -184,18 +200,18 @@ Cada página debe incluir los siguientes metadatos para optimización SEO:
 
 - **Title**: Título descriptivo y conciso
 - **Description**: Descripción breve del contenido
-- **Keywords**: Palabras clave relevantes
 
-Estos metadatos se pasan como props al componente Layout:
+Estos metadatos se pasan como props al componente `BaseLayout` (que solo acepta `title` y `description`; no hay prop `keywords`):
 
 ```astro
-<Layout 
+<BaseLayout
   title="Título de la Página | S&G Soluciones de Ingeniería"
-  description="Descripción para SEO"
-  keywords="palabras, clave, relevantes">
+  description="Descripción para SEO">
   <!-- Contenido -->
-</Layout>
+</BaseLayout>
 ```
+
+Para la estrategia de SEO completa (sitemap, meta tags, Open Graph), ver [`seo-optimizacion.md`](./seo-optimizacion.md).
 
 ## Consideraciones de Rendimiento
 

--- a/docs/guia-de-uso.md
+++ b/docs/guia-de-uso.md
@@ -22,11 +22,12 @@ Este proyecto es la landing page oficial de S&G Soluciones de Ingeniería, una e
 - Soluciones de automatización de procesos industriales
 - Proyectos de Industria 4.0, IoT y desarrollo de software
 
-El sitio web está desarrollado utilizando Astro, con un enfoque en mantener HTML puro, JavaScript (preferiblemente Vue) y CSS con Tailwind. La estructura del sitio consta de tres páginas principales:
+El sitio web está desarrollado como un sitio estático (SSG) con Astro, con foco en HTML semántico, JavaScript mínimo (vanilla) y CSS con Tailwind más el sistema de diseño propio "Nocturne". La estructura del sitio consta de estas rutas principales:
 
-1. Página principal (Home)
-2. Casos de éxito
-3. Contacto
+1. Página principal (`index.astro`)
+2. Contacto (`contacto.astro`)
+3. Listado de proyectos (`proyectos/index.astro`)
+4. Detalle de proyecto (`proyectos/[slug].astro`), ruta dinámica sobre la colección de contenido `proyectos`
 
 ## Instalación
 
@@ -57,25 +58,36 @@ El proyecto sigue la estructura estándar de Astro:
 │   └── favicon.svg
 ├── src/
 │   ├── assets/          # Imágenes, fuentes y otros recursos
-│   ├── components/      # Componentes reutilizables
-│   ├── layouts/         # Plantillas de diseño
-│   └── pages/           # Páginas del sitio
-│       ├── index.astro  # Página principal
-│       ├── casos-exito.astro  # Página de casos de éxito
-│       └── contacto.astro  # Página de contacto
+│   ├── components/
+│   │   └── nocturne/    # Componentes de sección del sistema de diseño "Nocturne"
+│   ├── content/
+│   │   ├── config.ts    # Schema Zod de la colección `proyectos`
+│   │   └── proyectos/   # Entradas MDX de casos/proyectos
+│   ├── layouts/
+│   │   └── BaseLayout.astro  # Layout único del sitio
+│   ├── pages/           # Páginas del sitio
+│   │   ├── index.astro           # Página principal
+│   │   ├── contacto.astro        # Página de contacto
+│   │   └── proyectos/
+│   │       ├── index.astro       # Listado de proyectos
+│   │       └── [slug].astro      # Detalle de proyecto
+│   └── styles/
+│       └── nocturne.css # Sistema de diseño "Nocturne" (tokens y clases)
 ├── astro.config.mjs     # Configuración de Astro
 ├── package.json         # Dependencias y scripts
 └── tsconfig.json        # Configuración de TypeScript
 ```
 
+Para el detalle completo de la estructura, ver [`estructura-proyecto.md`](./estructura-proyecto.md).
+
 ## Guía de Estilo
 
-El diseño del sitio debe seguir estas pautas:
+El diseño del sitio sigue el sistema "Nocturne", definido en `src/styles/nocturne.css` e importado desde `BaseLayout.astro`:
 
 - **Estilo**: Moderno, empresarial, atractivo y minimalista
-- **Paleta de colores**: [Pendiente de definir]
-- **Tipografía**: [Pendiente de definir]
-- **Componentes**: Utilizar Tailwind CSS para estilos consistentes
+- **Paleta de colores**: tokens CSS `--teal`, `--navy`, `--ink`, `--paper`, `--line`, `--muted` (expuestos también como colores de Tailwind: `teal`, `navy`, `ink`, `paper`, `line`, `muted` en `tailwind.config.js`)
+- **Tipografía**: Barlow (texto general, token `body`) y Barlow Condensed (títulos/kickers, token `cond`), cargadas desde Google Fonts en `BaseLayout.astro`
+- **Componentes**: Tailwind CSS para utilidades + clases propias de Nocturne (`.kick`, `.btn-t`/`.btn-o`, `.sec`, `.phead`, `.factbar`, `.prose-n`, entre otras)
 
 ### Principios de Diseño
 
@@ -88,23 +100,18 @@ El diseño del sitio debe seguir estas pautas:
 
 ### Funcionalidades Implementadas
 
-#### Modo Claro/Oscuro
+#### Navegación fija y scroll-reveal
 
-El sitio incluye un sistema completo de temas claro y oscuro:
+`BaseLayout.astro` incluye un script inline con dos comportamientos globales:
 
 **Características:**
-- **Detección automática**: Respeta la preferencia del sistema operativo del usuario
-- **Persistencia**: Guarda la preferencia del usuario en localStorage
-- **Múltiples controles**: Botones de tema en la navegación principal y botón flotante
-- **Transiciones suaves**: Cambios de tema con animaciones fluidas
-- **Accesibilidad**: Etiquetas ARIA y tooltips descriptivos
-- **Iconografía clara**: Iconos de sol/luna que cambian según el tema activo
+- **Nav sólida al hacer scroll**: la barra de navegación (`.nav`) agrega la clase `.solid` al superar 40px de scroll vertical
+- **Reveal on scroll**: cualquier elemento con la clase `.rv` recibe `.in` cuando entra en el viewport (vía `IntersectionObserver`, threshold 0.15), disparando su animación de aparición
 
 **Implementación técnica:**
-- **Configuración Tailwind**: `darkMode: 'class'` en `tailwind.config.mjs`
-- **Script global**: Función `window.toggleTheme()` disponible en toda la aplicación
-- **Eventos personalizados**: Sistema de notificación para cambios de tema
-- **Compatibilidad Astro**: Manejo correcto de navegación SPA
+- Script `is:inline` al final del `<body>` en `src/layouts/BaseLayout.astro`
+- No requiere JavaScript de terceros: es vanilla JS mínimo
+- El sitio es SSG (sin hidratación de frameworks); todo el comportamiento interactivo es JS vanilla puntual como este
 
 #### Modal de Galería de Imágenes
 
@@ -183,7 +190,7 @@ Para contribuir al proyecto:
 
 ## Despliegue
 
-[Pendiente de definir el proceso de despliegue]
+El sitio se despliega en **Dokploy** (build multi-stage con Astro + Nginx). Ver la guía completa en [`despliegue-dokploy.md`](./despliegue-dokploy.md).
 
 ---
 

--- a/docs/guia-desarrollo.md
+++ b/docs/guia-desarrollo.md
@@ -20,30 +20,34 @@ Utilizamos [Tailwind CSS](https://tailwindcss.com/) para los estilos por su enfo
 
 **Ventajas clave:**
 - Desarrollo rápido con clases utilitarias
-- Personalización a través de `tailwind.config.mjs`
+- Personalización a través de `tailwind.config.js`
 - Optimización automática para producción
 - Consistencia en el diseño
 
 ### Estándares de Diseño
 
+El sitio sigue el sistema de diseño **"Nocturne"**, definido en `src/styles/nocturne.css` e importado una única vez desde `BaseLayout.astro`.
+
 **Colores Corporativos:**
-Todos los colores están definidos en `tailwind.config.mjs` y deben coincidir con el diseño original:
+Los tokens de color están definidos como CSS custom properties en `src/styles/nocturne.css` y expuestos también como colores de Tailwind en `tailwind.config.js`:
 
 ```javascript
 colors: {
-  primary: '#2DD4BF',      // Teal principal
-  secondary: '#1E3A8A',    // Azul secundario
-  'dark-blue': '#0F172A',  // Azul oscuro
-  accent: '#FFD700',       // Dorado para acentos
-  dark: '#333333',         // Gris oscuro
-  light: '#F8FAFC'         // Gris claro
+  teal: { DEFAULT: '#00a79d', 300: '#7fd8cf', 600: '#009088', 700: '#00706a', 50: '#e7f6f3' },
+  navy: '#122a49',
+  ink: { DEFAULT: '#0d1417', 2: '#141d21' },
+  paper: { DEFAULT: '#f4f6f6', 2: '#eceff0' },
+  line: '#d9dedf',
+  muted: '#5b6567',
 }
 ```
 
+No existe la paleta `primary`/`secondary`/`dark-blue`/`light-gray`; pertenecía al diseño anterior.
+
 **Iconografía:**
-- Utilizar Font Awesome para iconos consistentes
-- Iconos específicos por sección (fa-robot, fa-cloud, fa-chart-line, etc.)
-- Aplicar clases `.service-icon` para efectos hover uniformes
+- Utilizar `astro-icon` con el set de Iconify `@iconify-json/mdi` para iconos consistentes
+- No se usa Font Awesome en este proyecto
+- Aplicar las clases de Nocturne (`.svc`, `.svc-grid`, etc.) para efectos hover uniformes en iconos de servicios
 
 ## Estructura de Archivos
 
@@ -53,7 +57,7 @@ Los componentes se organizan en la carpeta `src/components/` y siguen estas conv
 
 - Nombres en PascalCase (ej. `ServiceCard.astro`)
 - Un componente por archivo
-- Componentes relacionados pueden agruparse en subcarpetas
+- Componentes relacionados pueden agruparse en subcarpetas (ej. `src/components/nocturne/` agrupa las secciones del sistema de diseño "Nocturne": `Hero`, `Servicios`, `Casos`, `Nosotros`, `Testimonios`, `Contacto`)
 
 **Estructura básica de un componente:**
 
@@ -95,22 +99,21 @@ const formattedTitle = title.toUpperCase();
 
 Las páginas se almacenan en `src/pages/` y siguen estas convenciones:
 
-- Nombres en kebab-case (ej. `casos-exito.astro`)
+- Nombres en kebab-case (ej. `contacto.astro`)
 - Rutas automáticas basadas en la estructura de archivos
-- Metadatos SEO consistentes
+- Metadatos SEO consistentes (`title` y `description`)
 
 **Estructura básica de una página:**
 
 ```astro
 ---
 // Importaciones
-import Layout from '../layouts/Layout.astro';
+import BaseLayout from '../layouts/BaseLayout.astro';
 import ServiceCard from '../components/ServiceCard.astro';
 
 // Metadatos SEO
 const title = "Servicios | S&G Soluciones de Ingeniería";
 const description = "Descubre nuestros servicios de automatización industrial, desarrollo de software y soluciones IoT para optimizar tus procesos.";
-const keywords = "servicios, automatización industrial, desarrollo software, IoT, ingeniería";
 
 // Datos de la página
 const services = [
@@ -123,7 +126,7 @@ const services = [
 ];
 ---
 
-<Layout title={title} description={description} keywords={keywords}>
+<BaseLayout title={title} description={description}>
   <main class="container mx-auto py-12 px-4">
     <h1 class="text-4xl font-bold text-center mb-12">Nuestros Servicios</h1>
     
@@ -137,73 +140,53 @@ const services = [
       ))}
     </div>
   </main>
-</Layout>
+</BaseLayout>
 ```
 
 ### Layouts
 
-Los layouts se almacenan en `src/layouts/` y proporcionan la estructura común para las páginas.
+El sitio tiene un único layout, `src/layouts/BaseLayout.astro`, usado por todas las páginas. Solo acepta `title` y `description` como props (no hay `keywords` ni `ogImage`).
 
-**Estructura básica de un layout:**
+**Estructura real del layout** (ver `src/layouts/BaseLayout.astro`):
 
 ```astro
 ---
-// Importaciones
-import '../styles/global.css';
+// src/layouts/BaseLayout.astro — Rediseño "Nocturne"
+import '../styles/nocturne.css';
 
-// Definición de props
 interface Props {
   title: string;
-  description: string;
-  keywords: string;
-  ogImage?: string;
+  description?: string;
 }
 
-// Destructuración de props con valores por defecto
-const { 
-  title, 
-  description, 
-  keywords,
-  ogImage = "/images/og-default.jpg" 
+const {
+  title,
+  description = 'Ingeniería en automatización industrial, Industria 4.0 / IoT, gestión de energía y desarrollo de software a la medida.',
 } = Astro.props;
-
-// URL canónica
-const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 ---
 
-<!DOCTYPE html>
+<!doctype html>
 <html lang="es">
   <head>
-    <!-- Metadatos básicos -->
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width" />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>{title}</title>
     <meta name="description" content={description} />
-    <meta name="keywords" content={keywords} />
-    <link rel="canonical" href={canonicalURL} />
-    
-    <!-- Open Graph -->
-    <meta property="og:title" content={title} />
-    <meta property="og:description" content={description} />
-    <meta property="og:type" content="website" />
-    <meta property="og:url" content={canonicalURL} />
-    <meta property="og:image" content={ogImage} />
-    
-    <!-- Twitter -->
-    <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content={title} />
-    <meta name="twitter:description" content={description} />
-    <meta name="twitter:image" content={ogImage} />
-    
-    <!-- Fuentes -->
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=Montserrat:wght@500;600;700&display=swap" rel="stylesheet">
+
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@500;600;700&display=swap"
+      rel="stylesheet"
+    />
   </head>
-  <body class="min-h-screen bg-light text-dark">
-    <!-- Contenido de la página -->
+  <body id="top">
+    <nav class="nav" id="nav"><!-- ... --></nav>
     <slot />
+    <footer class="site"><!-- ... --></footer>
+    <script is:inline>
+      // Nav sólida al hacer scroll + reveal on scroll para elementos .rv
+    </script>
   </body>
 </html>
 ```
@@ -222,7 +205,7 @@ const canonicalURL = new URL(Astro.url.pathname, Astro.site);
 - Utiliza las clases de Tailwind siempre que sea posible
 - Agrupa las clases por categoría para mejorar la legibilidad
 - Para estilos específicos de componentes, usa la etiqueta `<style>` en el componente
-- Para estilos globales, utiliza `src/styles/global.css`
+- Para estilos globales, utiliza `src/styles/nocturne.css`
 
 ### JavaScript
 
@@ -301,6 +284,8 @@ Esto generará una versión optimizada del sitio en la carpeta `dist/`.
 - Comprueba que los enlaces internos y externos funcionen
 - Asegura que los formularios envíen datos correctamente
 - Verifica que los metadatos SEO estén presentes en todas las páginas
+
+El sitio se despliega en **Dokploy** (Astro build → imagen Nginx). Ver la guía completa en [`despliegue-dokploy.md`](./despliegue-dokploy.md).
 
 ## Recursos Útiles
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@astrojs/mdx": "^4.3.4",
         "@astrojs/sitemap": "^3.7.3",
         "@iconify-json/mdi": "^1.2.3",
-        "@splidejs/splide": "^4.1.4",
         "astro": "^5.13.4",
         "astro-icon": "^1.1.5",
         "zod": "^3.25.76"
@@ -1896,12 +1895,6 @@
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
-      "license": "MIT"
-    },
-    "node_modules/@splidejs/splide": {
-      "version": "4.1.4",
-      "resolved": "https://registry.npmjs.org/@splidejs/splide/-/splide-4.1.4.tgz",
-      "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA==",
       "license": "MIT"
     },
     "node_modules/@types/debug": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@astrojs/mdx": "^4.3.4",
     "@astrojs/sitemap": "^3.7.3",
     "@iconify-json/mdi": "^1.2.3",
-    "@splidejs/splide": "^4.1.4",
     "astro": "^5.13.4",
     "astro-icon": "^1.1.5",
     "zod": "^3.25.76"


### PR DESCRIPTION
## Resumen

- Actualiza `docs/guia-de-uso.md`, `docs/estructura-proyecto.md`, `docs/guia-desarrollo.md` y `docs/contribucion.md`, que describían el sitio pre-rediseño (`Layout.astro`, `global.css`, `casos-exito.astro`, paleta `primary/secondary/dark-blue/light-gray`, Font Awesome, Splide) y quedaron desactualizados tras el rediseño "Nocturne".
- Los docs ahora reflejan la arquitectura real: layout único `BaseLayout.astro`, sistema de diseño `src/styles/nocturne.css` (tokens `teal/navy/ink/paper/line/muted`, tipografías Barlow/Barlow Condensed), componentes en `src/components/nocturne/`, colección de contenido `proyectos` (`src/content/config.ts` + MDX), páginas reales (`index`, `contacto`, `proyectos/index`, `proyectos/[slug]`) y despliegue en Dokploy (remitiendo a `docs/despliegue-dokploy.md`).
- Elimina `@splidejs/splide` de `dependencies` en `package.json`: no tiene ningún import ni referencia en `src/` (confirmado con grep). Se corrió `npm install` para actualizar `package-lock.json` en consecuencia.
- No se tocó diseño, páginas ni componentes.

## Test plan
- [x] `npm run build` pasa y genera las 7 páginas esperadas
- [x] `rg -i splide src/` y `rg -i "font.?awesome|fa-" src/` devuelven cero resultados
