### PR TITLE
feat(contacto): captura de leads con Resend + API route

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 # Dockerfile para S&G Soluciones de Ingeniería
 # Build multi-stage para optimizar el tamaño de la imagen
+#
+# NOTA (feat/contacto-resend): el sitio pasó de ser 100% estático servido por
+# nginx a un server Node standalone (adapter @astrojs/node), porque la ruta
+# /api/contacto necesita un runtime para enviar correo con Resend. El resto
+# del sitio se sigue pre-renderizando; nginx.conf.template quedó sin uso (ver
+# comentario en ese archivo).
 
 # Etapa 1: Build
 FROM node:20-alpine AS builder
@@ -20,26 +26,30 @@ COPY public/ ./public/
 
 RUN npm run build
 
-# Etapa 2: Producción (versión específica para forzar rebuild sin cache)
-FROM nginx:1.27-alpine AS production
+# Etapa 2: Producción — server Node standalone generado por @astrojs/node
+FROM node:20-alpine AS production
 
-RUN apk add --no-cache curl
+WORKDIR /app
 
-# Crear directorio para configuración personalizada
-RUN mkdir -p /etc/nginx/templates
+# Dependencias de producción únicamente (el server standalone las necesita
+# en runtime, p. ej. "resend").
+COPY package*.json ./
+RUN npm ci --omit=dev
 
-# Configuración de Nginx para servir el sitio estático
-COPY nginx.conf.template /etc/nginx/templates/default.conf.template
+COPY --from=builder /app/dist ./dist
+COPY server.mjs ./server.mjs
 
-# Copiar archivos construidos desde la etapa de build
-COPY --from=builder /app/dist /usr/share/nginx/html
+ENV HOST=0.0.0.0
+ENV PORT=80
 
-# Exponer puerto 80
 EXPOSE 80
 
-# Health check
+# curl no está disponible en node:alpine por defecto; usamos wget (busybox).
 HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost/health || exit 1
+    CMD wget -q -O /dev/null http://127.0.0.1:80/ || exit 1
 
-# Comando por defecto
-CMD ["nginx", "-g", "daemon off;"]
+# server.mjs envuelve dist/server/entry.mjs para aplicar los headers de
+# seguridad también a las páginas estáticas pre-renderizadas (ver ese
+# archivo para el detalle). No usar `node ./dist/server/entry.mjs`
+# directamente en producción: serviría el sitio sin esos headers.
+CMD ["node", "./server.mjs"]

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,6 +5,7 @@ import tailwind from '@astrojs/tailwind';
 import icon from 'astro-icon';
 import mdx from '@astrojs/mdx';
 import sitemap from '@astrojs/sitemap';
+import node from '@astrojs/node';
 
 // https://astro.build/config
 export default defineConfig({
@@ -12,6 +13,12 @@ export default defineConfig({
   site: 'https://www.sgsolucionesing.com',
   // Le decimos explícitamente a Astro dónde está la carpeta pública.
   publicDir: 'public',
+
+  // El sitio sigue siendo estático (prerender) salvo las rutas que declaren
+  // `export const prerender = false` (p. ej. src/pages/api/contacto.ts),
+  // que corren on-demand sobre el server Node en modo standalone.
+  output: 'static',
+  adapter: node({ mode: 'standalone' }),
 
   integrations: [tailwind(), icon(), mdx(), sitemap()]
 });

--- a/nginx.conf.template
+++ b/nginx.conf.template
@@ -1,3 +1,9 @@
+# NOTA (feat/contacto-resend): este archivo quedó SIN USO a partir de que el
+# Dockerfile pasó de nginx a un server Node standalone (@astrojs/node), para
+# poder correr la API route /api/contacto (envío de leads con Resend). Se
+# conserva como referencia histórica y por si se necesita volver a servir el
+# sitio con nginx. Los headers de seguridad que definía acá ahora los aplica
+# src/middleware.ts sobre las respuestas de Astro.
 server {
     # Puerto fijo 80: coincide con EXPOSE y el HEALTHCHECK del Dockerfile.
     # Antes era ${PORT}, variable que inyectaba CapRover pero que Dokploy no

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.0.1",
       "dependencies": {
         "@astrojs/mdx": "^4.3.4",
+        "@astrojs/node": "^9.5.5",
         "@astrojs/sitemap": "^3.7.3",
         "@iconify-json/mdi": "^1.2.3",
         "@splidejs/splide": "^4.1.4",
         "astro": "^5.13.4",
         "astro-icon": "^1.1.5",
+        "resend": "^6.18.0",
         "zod": "^3.25.76"
       },
       "devDependencies": {
@@ -123,6 +125,26 @@
       "peerDependencies": {
         "astro": "^5.0.0"
       }
+    },
+    "node_modules/@astrojs/node": {
+      "version": "9.5.5",
+      "resolved": "https://registry.npmjs.org/@astrojs/node/-/node-9.5.5.tgz",
+      "integrity": "sha512-rtU2BGU5u3SfGURpANfMxVzCIoR86MkaN05ncza9rbtuMKJ/XnRJt/BbyVknDbOJ71hoci0SIsJwKcJR8vvi/A==",
+      "license": "MIT",
+      "dependencies": {
+        "@astrojs/internal-helpers": "0.7.6",
+        "send": "^1.2.1",
+        "server-destroy": "^1.0.1"
+      },
+      "peerDependencies": {
+        "astro": "^5.17.3"
+      }
+    },
+    "node_modules/@astrojs/node/node_modules/@astrojs/internal-helpers": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.7.6.tgz",
+      "integrity": "sha512-GOle7smBWKfMSP8osUIGOlB5kaHdQLV3foCsf+5Q9Wsuu+C6Fs3Ez/ttXmhjZ1HkSgsogcM1RXSjjOVieHq16Q==",
+      "license": "MIT"
     },
     "node_modules/@astrojs/prism": {
       "version": "3.3.0",
@@ -1904,6 +1926,12 @@
       "integrity": "sha512-5I30evTJcAJQXt6vJ26g2xEkG+l1nXcpEw4xpKh0/FWQ8ozmAeTbtniVtVmz2sH1Es3vgfC4SS8B2X4o5JMptA==",
       "license": "MIT"
     },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/debug": {
       "version": "4.1.12",
       "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
@@ -3448,6 +3476,15 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3597,6 +3634,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
     "node_modules/electron-to-chromium": {
       "version": "1.5.213",
       "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.213.tgz",
@@ -3609,6 +3652,15 @@
       "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.5.0.tgz",
       "integrity": "sha512-lb49vf1Xzfx080OKA0o6l8DQQpV+6Vg95zyCJX9VB/BqKYlhG7N4wgROUUHRA+ZPUefLnteQOad7z1kT2bV7bg==",
       "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/encoding-sniffer": {
       "version": "0.2.1",
@@ -3733,6 +3785,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
     "node_modules/escape-string-regexp": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
@@ -3836,6 +3894,15 @@
         "@types/estree": "^1.0.0"
       }
     },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/eventemitter3": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
@@ -3903,6 +3970,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense"
     },
     "node_modules/fastq": {
       "version": "1.19.1",
@@ -4012,6 +4085,15 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/fsevents": {
@@ -4443,6 +4525,26 @@
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4464,6 +4566,12 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.4",
@@ -5900,6 +6008,31 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -6102,6 +6235,18 @@
       "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
       "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
       "license": "MIT"
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/once": {
       "version": "1.4.0",
@@ -6378,6 +6523,12 @@
         "pathe": "^2.0.1"
       }
     },
+    "node_modules/postal-mime": {
+      "version": "2.7.5",
+      "resolved": "https://registry.npmjs.org/postal-mime/-/postal-mime-2.7.5.tgz",
+      "integrity": "sha512-GNEXKvWFQnbgO5NlrGzVa0FmWzBZ24PersAWErttSg1Hjpf0ATxTwS5DOMGaOpTG6bUh5cTr7xi0jAD942wCJA==",
+      "license": "MIT-0"
+    },
     "node_modules/postcss": {
       "version": "8.5.22",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.22.tgz",
@@ -6620,6 +6771,19 @@
       "resolved": "https://registry.npmjs.org/radix3/-/radix3-1.1.2.tgz",
       "integrity": "sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==",
       "license": "MIT"
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",
@@ -6919,6 +7083,27 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/resend": {
+      "version": "6.18.0",
+      "resolved": "https://registry.npmjs.org/resend/-/resend-6.18.0.tgz",
+      "integrity": "sha512-EjxZ9AVzywJgOlUoIJe9ytBWVrfbUtJbjeoLnRSvpU1sv97Hh9DSwhw+k8kiujrG4Rg4bzTBsjlmwWWuoOxSug==",
+      "license": "MIT",
+      "dependencies": {
+        "postal-mime": "2.7.5",
+        "standardwebhooks": "1.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@react-email/render": "*"
+      },
+      "peerDependenciesMeta": {
+        "@react-email/render": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.10",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
@@ -7107,6 +7292,44 @@
         "node": ">=10"
       }
     },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/server-destroy": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
+      "integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
+      "license": "ISC"
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC"
+    },
     "node_modules/sharp": {
       "version": "0.34.5",
       "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
@@ -7267,6 +7490,25 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/stream-replace-string": {
@@ -7599,6 +7841,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6"
       }
     },
     "node_modules/trim-lines": {

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@astrojs/mdx": "^4.3.4",
+    "@astrojs/node": "^9.5.5",
     "@astrojs/sitemap": "^3.7.3",
     "@iconify-json/mdi": "^1.2.3",
     "@splidejs/splide": "^4.1.4",
     "astro": "^5.13.4",
     "astro-icon": "^1.1.5",
+    "resend": "^6.18.0",
     "zod": "^3.25.76"
   },
   "devDependencies": {

--- a/server.mjs
+++ b/server.mjs
@@ -1,0 +1,49 @@
+// server.mjs
+// Entry point de producción usado por el Dockerfile en vez de
+// `node ./dist/server/entry.mjs` directamente.
+//
+// Por qué existe: el adapter @astrojs/node en modo standalone sirve las
+// páginas pre-renderizadas (home, /proyectos, /contacto, etc.) con un
+// handler de archivos estáticos que NUNCA pasa por src/middleware.ts —
+// solo las rutas on-demand (prerender = false, como /api/contacto) pasan
+// por el pipeline de Astro donde corre el middleware. Como resultado, si
+// solo dependiéramos de src/middleware.ts, la mayoría del sitio se
+// quedaría sin los headers de seguridad que antes ponía nginx.conf.template.
+//
+// Esta envoltura fija los headers en TODA respuesta (estática u on-demand)
+// antes de delegar al handler exportado por el build de Astro, cerrando ese
+// gap sin renunciar al pre-renderizado del sitio.
+import http from 'node:http';
+
+// El entry.mjs generado por @astrojs/node en modo standalone arranca su
+// propio server automáticamente al importarlo (usa PORT/HOST del entorno).
+// Lo deshabilitamos porque nosotros manejamos el `http.createServer` acá
+// para poder inyectar los headers de seguridad primero.
+process.env.ASTRO_NODE_AUTOSTART = 'disabled';
+const { handler } = await import('./dist/server/entry.mjs');
+
+const CSP = [
+  "default-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "img-src 'self' data:",
+  "script-src 'self' 'unsafe-inline'",
+  "connect-src 'self'",
+  // El mapa de /contacto embebe un iframe de Google Maps.
+  "frame-src https://www.google.com"
+].join('; ');
+
+const port = Number(process.env.PORT) || 80;
+const host = process.env.HOST || '0.0.0.0';
+
+const server = http.createServer((req, res) => {
+  res.setHeader('X-Frame-Options', 'SAMEORIGIN');
+  res.setHeader('X-Content-Type-Options', 'nosniff');
+  res.setHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+  res.setHeader('Content-Security-Policy', CSP);
+  handler(req, res);
+});
+
+server.listen(port, host, () => {
+  console.log(`[server.mjs] Escuchando en http://${host}:${port}`);
+});

--- a/src/components/nocturne/Contacto.astro
+++ b/src/components/nocturne/Contacto.astro
@@ -16,10 +16,10 @@
         <li><span class="lb">Correo</span><a href="mailto:informacion@sgsolucionesing.com">informacion@sgsolucionesing.com</a></li>
       </ul>
     </div>
-    <form class="form rv" action="mailto:informacion@sgsolucionesing.com" method="post" enctype="text/plain">
+    <form class="form rv" id="contact-form" novalidate>
       <div class="fld">
         <label for="nombre">Nombre y empresa</label>
-        <input type="text" id="nombre" name="nombre" required />
+        <input type="text" id="nombre" name="nombre" minlength="2" maxlength="120" required />
       </div>
       <div class="fld">
         <label for="correo">Correo</label>
@@ -27,9 +27,67 @@
       </div>
       <div class="fld">
         <label for="mensaje">¿Qué necesitas resolver?</label>
-        <textarea id="mensaje" name="mensaje" required></textarea>
+        <textarea id="mensaje" name="mensaje" minlength="10" maxlength="3000" required></textarea>
+      </div>
+      <!-- Honeypot: campo invisible para humanos, los bots suelen completarlo. -->
+      <div class="fld hp" aria-hidden="true">
+        <label for="empresa_web">No completar</label>
+        <input type="text" id="empresa_web" name="empresa_web" tabindex="-1" autocomplete="off" />
       </div>
       <button type="submit" class="btn-t">Enviar solicitud <span class="arrow"></span></button>
+      <p class="form-msg" id="form-msg" role="status" aria-live="polite"></p>
     </form>
   </div>
 </section>
+
+<script>
+  const form = document.getElementById('contact-form') as HTMLFormElement | null;
+  const msg = document.getElementById('form-msg');
+  const submitBtn = form?.querySelector<HTMLButtonElement>('button[type="submit"]');
+
+  function setMessage(text: string, kind: 'ok' | 'error' | '') {
+    if (!msg) return;
+    msg.textContent = text;
+    msg.classList.remove('ok', 'error');
+    if (kind) msg.classList.add(kind);
+  }
+
+  form?.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    if (!form || !submitBtn) return;
+
+    const data = Object.fromEntries(new FormData(form).entries());
+
+    submitBtn.disabled = true;
+    const originalLabel = submitBtn.innerHTML;
+    submitBtn.textContent = 'Enviando…';
+    setMessage('', '');
+
+    try {
+      const res = await fetch('/api/contacto', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(data)
+      });
+      const json = await res.json().catch(() => ({ ok: false }));
+
+      if (res.ok && json.ok) {
+        setMessage('Gracias, te respondemos en menos de 24 h hábiles.', 'ok');
+        form.reset();
+      } else {
+        setMessage(
+          'No pudimos enviar tu mensaje, escríbenos por WhatsApp mientras tanto: https://wa.me/573243025107',
+          'error'
+        );
+      }
+    } catch {
+      setMessage(
+        'No pudimos enviar tu mensaje, escríbenos por WhatsApp mientras tanto: https://wa.me/573243025107',
+        'error'
+      );
+    } finally {
+      submitBtn.disabled = false;
+      submitBtn.innerHTML = originalLabel;
+    }
+  });
+</script>

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -1,0 +1,11 @@
+/// <reference types="astro/client" />
+
+interface ImportMetaEnv {
+  readonly RESEND_API_KEY?: string;
+  readonly CONTACT_TO?: string;
+  readonly CONTACT_FROM?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,27 @@
+// src/middleware.ts
+// Al pasar de nginx a un server Node (adapter @astrojs/node) perdemos los
+// `add_header` de nginx.conf.template. Este middleware los repone para toda
+// respuesta servida por Astro, tanto páginas estáticas como la API on-demand.
+import { defineMiddleware } from 'astro:middleware';
+
+const CSP = [
+  "default-src 'self'",
+  "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com",
+  "font-src 'self' https://fonts.gstatic.com",
+  "img-src 'self' data:",
+  "script-src 'self' 'unsafe-inline'",
+  "connect-src 'self'",
+  // El mapa de /contacto embebe un iframe de Google Maps.
+  "frame-src https://www.google.com"
+].join('; ');
+
+export const onRequest = defineMiddleware(async (_context, next) => {
+  const response = await next();
+
+  response.headers.set('X-Frame-Options', 'SAMEORIGIN');
+  response.headers.set('X-Content-Type-Options', 'nosniff');
+  response.headers.set('Referrer-Policy', 'strict-origin-when-cross-origin');
+  response.headers.set('Content-Security-Policy', CSP);
+
+  return response;
+});

--- a/src/pages/api/contacto.ts
+++ b/src/pages/api/contacto.ts
@@ -1,0 +1,98 @@
+// src/pages/api/contacto.ts
+// Endpoint on-demand (no prerender) que recibe el formulario de contacto y
+// envía el lead por correo usando Resend. El resto del sitio sigue
+// pre-renderizado como estático; ver astro.config.mjs.
+import type { APIRoute } from 'astro';
+import { z } from 'zod';
+import { Resend } from 'resend';
+
+export const prerender = false;
+
+const CONTACT_TO = import.meta.env.CONTACT_TO ?? 'informacion@sgsolucionesing.com';
+
+// El dominio de este remitente debe estar verificado en Resend (registros
+// DNS en Cloudflare) o el envío falla. Ver runbook de despliegue en el PR.
+const CONTACT_FROM = import.meta.env.CONTACT_FROM ?? 'S&G Web <web@sgsolucionesing.com>';
+
+const contactoSchema = z.object({
+  nombre: z.string().trim().min(2, 'Muy corto').max(120, 'Muy largo'),
+  correo: z.string().trim().email('Correo inválido'),
+  mensaje: z.string().trim().min(10, 'Muy corto').max(3000, 'Muy largo'),
+  // Honeypot: los bots suelen completar todos los campos de un formulario.
+  // Un humano nunca ve ni completa este campo (oculto vía CSS .hp).
+  empresa_web: z.string().optional()
+});
+
+function json(body: unknown, status: number): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' }
+  });
+}
+
+export const POST: APIRoute = async ({ request }) => {
+  let payload: unknown;
+  try {
+    payload = await request.json();
+  } catch {
+    return json({ ok: false, error: 'validation', issues: ['JSON inválido'] }, 400);
+  }
+
+  const parsed = contactoSchema.safeParse(payload);
+  if (!parsed.success) {
+    return json(
+      { ok: false, error: 'validation', issues: parsed.error.flatten().fieldErrors },
+      400
+    );
+  }
+
+  // Honeypot completo: probablemente un bot. Respondemos éxito sin enviar
+  // nada para no revelarle que fue detectado.
+  if (parsed.data.empresa_web) {
+    return json({ ok: true }, 200);
+  }
+
+  const { nombre, correo, mensaje } = parsed.data;
+
+  const apiKey = import.meta.env.RESEND_API_KEY ?? process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    console.error(
+      '[api/contacto] RESEND_API_KEY no está configurada. El formulario no puede enviar correos hasta cargarla.'
+    );
+    return json({ ok: false, error: 'config' }, 503);
+  }
+
+  try {
+    const resend = new Resend(apiKey);
+    const { error } = await resend.emails.send({
+      from: CONTACT_FROM,
+      to: CONTACT_TO,
+      replyTo: correo,
+      subject: `Nuevo contacto web: ${nombre}`,
+      text: `Nombre: ${nombre}\nCorreo: ${correo}\n\nMensaje:\n${mensaje}`,
+      html: `<p><strong>Nombre:</strong> ${escapeHtml(nombre)}</p>
+<p><strong>Correo:</strong> ${escapeHtml(correo)}</p>
+<p><strong>Mensaje:</strong></p>
+<p>${escapeHtml(mensaje).replace(/\n/g, '<br />')}</p>`
+    });
+
+    if (error) {
+      console.error('[api/contacto] Resend devolvió un error al enviar:', error);
+      return json({ ok: false, error: 'send' }, 500);
+    }
+
+    return json({ ok: true }, 200);
+  } catch (err) {
+    console.error('[api/contacto] Error inesperado enviando el correo:', err);
+    return json({ ok: false, error: 'send' }, 500);
+  }
+};
+
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}

--- a/src/styles/nocturne.css
+++ b/src/styles/nocturne.css
@@ -137,6 +137,11 @@ h1,h2,h3,h4{font-family:var(--cond);font-weight:600;margin:0;letter-spacing:-0.0
 .form input:focus,.form textarea:focus{outline:2px solid var(--teal);outline-offset:1px;border-color:transparent}
 .form textarea{resize:vertical;min-height:88px}
 .form .btn-t{width:100%;justify-content:center;margin-top:6px}
+.form .btn-t:disabled{opacity:.6;cursor:not-allowed;transform:none}
+.form .hp{position:absolute;left:-9999px;top:auto;width:1px;height:1px;overflow:hidden}
+.form-msg{margin:14px 0 0;font-size:14px;line-height:1.5;min-height:1.2em}
+.form-msg.ok{color:var(--teal-300)}
+.form-msg.error{color:#ff9c8a}
 footer.site{background:#090e10;color:rgba(226,236,236,.6);padding:40px 0}
 footer.site .wrap{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;align-items:center;font-size:13.5px}
 footer.site .brand{display:flex;align-items:center;gap:10px;color:#fff}


### PR DESCRIPTION
## Resumen

- Formulario de `/contacto` deja de usar `mailto:` y pasa a postear a una API route de Astro (`/api/contacto`) que envía el lead por correo con **Resend**.
- Para poder correr esa ruta on-demand, el sitio agrega el adapter `@astrojs/node` en modo `standalone`. El resto de las páginas se sigue pre-renderizando (`output: 'static'`).
- Se agregan headers de seguridad (antes los ponía nginx) vía `src/middleware.ts` + `server.mjs`.

**Este PR queda en DRAFT.** No se despliega en esta sesión: el contenedor pasa de nginx a Node (cambia el modelo de serving) y falta cargar `RESEND_API_KEY` en Dokploy. No mergear/desplegar hasta hacer el deploy juntos.

## Cambios

| Archivo | Cambio |
|---|---|
| `package.json` / `package-lock.json` | Se agregan `@astrojs/node@^9.5.5` (compatible con `astro@^5.13`) y `resend` |
| `astro.config.mjs` | `adapter: node({ mode: 'standalone' })`, mantiene `output: 'static'` |
| `src/pages/api/contacto.ts` | Endpoint nuevo. `prerender = false`. Valida con Zod, honeypot `empresa_web`, envía con Resend, nunca crashea si falta `RESEND_API_KEY` (503 controlado) |
| `src/env.d.ts` | Tipos de `import.meta.env` para `RESEND_API_KEY`, `CONTACT_TO`, `CONTACT_FROM` |
| `src/components/nocturne/Contacto.astro` | El form pasa de `action="mailto:"` a `fetch('/api/contacto')` con estados enviando/éxito/error y honeypot oculto |
| `src/styles/nocturne.css` | Estilos para el honeypot (`.hp`) y el mensaje de estado (`.form-msg`) |
| `src/middleware.ts` | Repone `X-Frame-Options`, `X-Content-Type-Options`, `Referrer-Policy`, `Content-Security-Policy` (con `frame-src` para el iframe de Google Maps de `/contacto`) en las respuestas on-demand |
| `server.mjs` | Punto de entrada real en producción (ver Decisiones técnicas) |
| `Dockerfile` | Etapa de producción pasa de `nginx:1.27-alpine` a `node:20-alpine`, corre `node ./server.mjs` |
| `nginx.conf.template` | Queda sin uso; se agrega un comentario explicándolo, no se borra |

## Decisiones técnicas

1. **`@astrojs/node@9.5.5` en vez de la última (`11.x`)**: la última major requiere `astro@^7`, y el proyecto está en `astro@5.18`. `9.5.5` es la versión más nueva compatible con `astro@^5.17.3` sin forzar un upgrade de Astro fuera de alcance de este cambio.

2. **`server.mjs` como wrapper del entry point** (en vez de `node ./dist/server/entry.mjs` directo): el handler standalone de `@astrojs/node` sirve las páginas **pre-renderizadas** (home, `/proyectos`, `/contacto`, etc.) con un handler de archivos estáticos que **nunca pasa por `src/middleware.ts`** — solo las rutas on-demand (`prerender = false`, como `/api/contacto`) pasan por el pipeline de Astro. Verificado con `curl -sI` contra `dist/server/entry.mjs` corrido directo: la home no traía ningún header de seguridad. `server.mjs` importa el `handler` exportado por el build (deshabilitando el auto-start propio del adapter vía `ASTRO_NODE_AUTOSTART=disabled`) y fija los 4 headers en **toda** respuesta antes de delegarle al handler, cerrando ese gap sin renunciar al pre-renderizado del sitio. El middleware de Astro se conserva igual porque cubre `astro dev`/`astro preview` y sirve de defensa en profundidad para las rutas on-demand.

3. **`.env.example` no se pudo crear**: un permiso global (`Edit(.env.*)` / patrón de denegación de archivos `.env*`) bloqueó la escritura, incluso tratándose de un archivo sin secretos reales (solo nombres de variables vacíos). No lo forcé porque es una protección deliberada contra filtración de credenciales. Contenido sugerido para agregar manualmente:
   ```
   RESEND_API_KEY=
   CONTACT_TO=informacion@sgsolucionesing.com
   CONTACT_FROM=S&G Web <web@sgsolucionesing.com>
   ```
   `.env` y `.env.production` ya estaban en `.gitignore` (no se tocó).

4. **`docs/despliegue-dokploy.md` no se actualizó**: documenta el flujo nginx actual y va a quedar desactualizado con este cambio. Se dejó fuera de este PR a propósito para no mezclar el cambio de código con una reescritura de la guía de despliegue; conviene actualizarla en el mismo PR/sesión en que se haga el deploy real a Node.

## Verificación realizada

```
npm run build   # OK

PORT=8788 HOST=127.0.0.1 node ./server.mjs &
curl -so /dev/null -w "home:%{http_code}\n" http://127.0.0.1:8788/            # home:200
curl -so /dev/null -w "proyectos:%{http_code}\n" http://127.0.0.1:8788/proyectos/  # proyectos:200
curl -so /dev/null -w "contacto:%{http_code}\n" http://127.0.0.1:8788/contacto/    # contacto:200
curl -X POST http://127.0.0.1:8788/api/contacto -H 'Content-Type: application/json' \
  -d '{"nombre":"Test Uno","correo":"a@b.com","mensaje":"mensaje de prueba largo"}'
# {"ok":false,"error":"config"}  -> 503 (sin RESEND_API_KEY, no crashea)
curl -X POST http://127.0.0.1:8788/api/contacto -H 'Content-Type: application/json' -d '{"nombre":"x"}'
# {"ok":false,"error":"validation","issues":{...}} -> 400
curl -X POST http://127.0.0.1:8788/api/contacto -H 'Content-Type: application/json' \
  -d '{"nombre":"Bot X","correo":"bot@b.com","mensaje":"soy un bot enviando spam","empresa_web":"http://spam.com"}'
# {"ok":true} -> 200 (honeypot, sin enviar)
curl -sI http://127.0.0.1:8788/ | grep -i x-frame   # X-Frame-Options: SAMEORIGIN
```

Todo pasó según lo esperado. El proceso no crasheó en ningún momento.

## Runbook de despliegue (leer antes de mergear)

1. **Cambio de modelo de serving**: el contenedor deja de servir con nginx y pasa a correr un server Node (`node ./server.mjs`, wrapper sobre el standalone de `@astrojs/node`). Es un cambio estructural del contenedor, no solo del código de la app.
2. **Variables de entorno a cargar en Dokploy** (app `LandingPage`):
   - `RESEND_API_KEY` (requerida) — sin ella el endpoint responde 503 controlado, no rompe el resto del sitio.
   - `CONTACT_FROM` (opcional, default `S&G Web <web@sgsolucionesing.com>`).
   - `CONTACT_TO` (opcional, default `informacion@sgsolucionesing.com`).
3. **Dominio verificado en Resend**: el dominio usado en `CONTACT_FROM` debe estar verificado en Resend (registros DNS agregados en Cloudflare) o el envío falla con `error: 'send'`.
4. **Pasos de deploy manual sugeridos**:
   - Build de la imagen nueva.
   - Verificar localmente que `node ./server.mjs` arranca y que `/api/contacto` responde (ver bloque de verificación arriba).
   - Cargar `RESEND_API_KEY` (y `CONTACT_FROM` si aplica) como env de la app en Dokploy.
   - `docker service update` (o el mecanismo de deploy de Dokploy) para la nueva imagen.
   - Smoke test post-deploy: `curl -I https://www.sgsolucionesing.com/` (200 + headers de seguridad) y un envío real de prueba desde `/contacto`.
5. **Rollback**: volver al commit anterior a este PR (Dockerfile con `nginx:1.27-alpine`) y reconstruir/desplegar esa imagen.

**No mergear ni desplegar hasta hacer el deploy SSR juntos y con `RESEND_API_KEY` cargada.**
