### PR TITLE
feat(seo): metadatos completos, Open Graph/Twitter y structured data

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -6,12 +6,21 @@ import '../styles/nocturne.css';
 interface Props {
   title: string;
   description?: string;
+  image?: string;
+  type?: string;
+  noindex?: boolean;
 }
 
 const {
   title,
   description = 'Ingeniería en automatización industrial, Industria 4.0 / IoT, gestión de energía y desarrollo de software a la medida.',
+  image = '/assets/img/pruebas-1.jpg',
+  type = 'website',
+  noindex = false,
 } = Astro.props;
+
+const canonical = new URL(Astro.url.pathname, Astro.site).href;
+const ogImage = new URL(image, Astro.site).href;
 ---
 
 <!doctype html>
@@ -22,12 +31,33 @@ const {
     <title>{title}</title>
     <meta name="description" content={description} />
 
+    <link rel="canonical" href={canonical} />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <meta name="theme-color" content="#0d1417" />
+    <meta name="author" content="S&G Soluciones de Ingeniería" />
+    {noindex && <meta name="robots" content="noindex, nofollow" />}
+
+    <meta property="og:type" content={type} />
+    <meta property="og:site_name" content="S&G Soluciones de Ingeniería" />
+    <meta property="og:locale" content="es_CO" />
+    <meta property="og:title" content={title} />
+    <meta property="og:description" content={description} />
+    <meta property="og:url" content={canonical} />
+    <meta property="og:image" content={ogImage} />
+
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content={title} />
+    <meta name="twitter:description" content={description} />
+    <meta name="twitter:image" content={ogImage} />
+
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@500;600;700&display=swap"
       rel="stylesheet"
     />
+
+    <slot name="head" />
   </head>
   <body id="top">
     <nav class="nav" id="nav">

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -8,7 +8,15 @@ const pageDescription =
   'Ponte en contacto con nuestro equipo de expertos en soluciones de ingeniería, automatización industrial y desarrollo de software.';
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={pageTitle} description={pageDescription} image="/assets/img/pruebas-1.jpg">
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'ContactPage',
+    name: pageTitle,
+    description: pageDescription,
+    url: 'https://www.sgsolucionesing.com/contacto',
+  })} />
+
   <header class="phead">
     <div class="bg"><img src="/assets/img/pruebas-1.jpg" alt="" aria-hidden="true" /></div>
     <div class="wrap">

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,8 +6,40 @@ import Casos from '../components/nocturne/Casos.astro';
 import Nosotros from '../components/nocturne/Nosotros.astro';
 import Testimonios from '../components/nocturne/Testimonios.astro';
 import Contacto from '../components/nocturne/Contacto.astro';
+
+const pageTitle = 'S&G Soluciones de Ingeniería | Automatización industrial, IoT y software';
+const pageDescription =
+  'Automatización industrial, Industria 4.0/IoT, gestión de energía y desarrollo de software a la medida para la industria de la Región Caribe de Colombia.';
 ---
-<BaseLayout title="S&G Soluciones de Ingeniería | Automatización industrial, IoT y software" description="Ingeniería en automatización industrial, Industria 4.0 / IoT, gestión de energía y desarrollo de software a la medida para la industria de la costa norte de Colombia.">
+<BaseLayout title={pageTitle} description={pageDescription} image="/assets/img/pruebas-1.jpg">
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'ProfessionalService',
+    name: 'S&G Soluciones de Ingeniería',
+    url: 'https://www.sgsolucionesing.com',
+    logo: 'https://www.sgsolucionesing.com/logo.png',
+    image: 'https://www.sgsolucionesing.com/assets/img/pruebas-1.jpg',
+    description:
+      'Empresa de ingeniería especializada en automatización industrial, Industria 4.0/IoT, gestión y calidad de energía, y desarrollo de software a la medida para la industria de la Región Caribe de Colombia.',
+    telephone: '+573243025107',
+    email: 'informacion@sgsolucionesing.com',
+    address: {
+      '@type': 'PostalAddress',
+      addressLocality: 'Barranquilla',
+      addressRegion: 'Atlántico',
+      addressCountry: 'CO',
+    },
+    areaServed: 'Región Caribe, Colombia',
+    knowsAbout: [
+      'Automatización industrial',
+      'Industria 4.0',
+      'IoT industrial',
+      'Gestión de energía',
+      'SCADA',
+      'Desarrollo de software industrial',
+    ],
+  })} />
+
   <Hero />
   <Servicios />
   <Casos />

--- a/src/pages/proyectos/[slug].astro
+++ b/src/pages/proyectos/[slug].astro
@@ -17,22 +17,47 @@ const data = proyecto.data;
 
 const pageTitle = `${data.title} | Caso de Éxito - S&G Soluciones de Ingeniería`;
 const pageDescription = data.resumen;
+const coverImageUrl = new URL(data.coverImage, Astro.site).href;
+const logoUrl = new URL('/logo.png', Astro.site).href;
+const canonicalUrl = new URL(Astro.url.pathname, Astro.site).href;
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={pageTitle} description={pageDescription} image={data.coverImage} type="article">
   <script type="application/ld+json" slot="head" set:html={JSON.stringify({
     '@context': 'https://schema.org',
-    '@type': 'CaseStudy',
-    name: data.title,
-    industry: data.sector,
-    location: data.ubicacion,
-    datePublished: data.fecha,
+    '@type': 'Article',
+    headline: data.title,
+    image: [coverImageUrl],
     description: data.resumen,
-    provider: {
+    ...(data.fecha ? { datePublished: data.fecha } : {}),
+    about: data.sector,
+    author: {
       '@type': 'Organization',
       name: 'S&G Soluciones de Ingeniería',
-      url: 'https://sgsolucionesing.com',
+      url: 'https://www.sgsolucionesing.com',
     },
+    publisher: {
+      '@type': 'Organization',
+      name: 'S&G Soluciones de Ingeniería',
+      url: 'https://www.sgsolucionesing.com',
+      logo: {
+        '@type': 'ImageObject',
+        url: logoUrl,
+      },
+    },
+    mainEntityOfPage: {
+      '@type': 'WebPage',
+      '@id': canonicalUrl,
+    },
+  })} />
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: 'https://www.sgsolucionesing.com/' },
+      { '@type': 'ListItem', position: 2, name: 'Casos de éxito', item: 'https://www.sgsolucionesing.com/proyectos' },
+      { '@type': 'ListItem', position: 3, name: data.title, item: canonicalUrl },
+    ],
   })} />
 
   <header class="phead">

--- a/src/pages/proyectos/index.astro
+++ b/src/pages/proyectos/index.astro
@@ -8,10 +8,26 @@ const items = (await getCollection('proyectos'))
 
 const pageTitle = 'Casos de Éxito | S&G Soluciones de Ingeniería';
 const pageDescription =
-  'Explora nuestros proyectos reales de automatización industrial, IoT e Industria 4.0: monitoreo predictivo, bancos de condensadores, tableros inteligentes y más.';
+  'Casos reales de automatización industrial, IoT e Industria 4.0: monitoreo predictivo, bancos de condensadores, tableros inteligentes y más resultados medibles.';
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription}>
+<BaseLayout title={pageTitle} description={pageDescription} image="/assets/img/tablero-1.jpg">
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'CollectionPage',
+    name: pageTitle,
+    description: pageDescription,
+    url: 'https://www.sgsolucionesing.com/proyectos',
+  })} />
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify({
+    '@context': 'https://schema.org',
+    '@type': 'BreadcrumbList',
+    itemListElement: [
+      { '@type': 'ListItem', position: 1, name: 'Inicio', item: 'https://www.sgsolucionesing.com/' },
+      { '@type': 'ListItem', position: 2, name: 'Casos de éxito', item: 'https://www.sgsolucionesing.com/proyectos' },
+    ],
+  })} />
+
   <header class="phead">
     <div class="bg"><img src="/assets/img/tablero-1.jpg" alt="" aria-hidden="true" /></div>
     <div class="wrap">


### PR DESCRIPTION
Mejora del SEO técnico del sitio. **Sin cambios de diseño ni de contenido de negocio** — solo `<head>`, metadatos y datos estructurados.

## Por qué
El rediseño "Nocturne" había dejado el `BaseLayout` solo con `<title>` + `<meta description>`, **perdiendo** el Open Graph, Twitter Cards y canonical que tenía el layout anterior. Además el `[slug].astro` inyectaba JSON-LD con `slot="head"` pero el layout **no tenía** ese slot → el structured data del detalle **se descartaba** (no llegaba al HTML).

## Cambios
- **`BaseLayout.astro`**: `<link rel="canonical">`, favicon SVG, `theme-color`, `author`, **Open Graph** (type/site_name/locale/title/description/url/image) y **Twitter Card** (`summary_large_image`), con props opcionales `image`/`type`/`noindex` resueltos contra `Astro.site`. Se agrega `<slot name="head" />` al final del `<head>` → **corrige el JSON-LD descartado** y habilita inyección por página. Nav, footer, scripts y fuentes intactos.
- **Home**: JSON-LD `ProfessionalService` con NAP real (S&G, Barranquilla/Atlántico/CO, tel `+57 324 3025107`, email, área Región Caribe, servicios) → **SEO local**.
- **Detalle de proyecto**: OG usa la **portada real del caso** (`type="article"`); se reemplaza el `@type:"CaseStudy"` (inválido en schema.org) por **`Article`** válido (headline, image absoluta, description, datePublished, about=sector, publisher Organization con logo) + **`BreadcrumbList`**.
- **Listado**: `CollectionPage` + `BreadcrumbList`. **Contacto**: `ContactPage`.
- Meta descriptions pulidas (~150-160 chars, español profesional).

## Verificación
- `npm run build` OK (7 páginas). El HTML estático sale en `dist/client/` (adapter Node standalone).
- `dist/client/index.html`: canonical, `og:*`, `twitter:card`, favicon y JSON-LD `ProfessionalService` presentes en `<head>`.
- `dist/client/proyectos/<slug>/index.html`: `og:type=article`, `og:image` = portada absoluta del caso, y `Article` + `BreadcrumbList` **ahora sí en `<head>`**.
- `sitemap-0.xml` lista home, contacto, proyectos y los 4 detalles; canonical/og:url con `https://www.sgsolucionesing.com` + pathname por página.

## Nota
La `og:image` por defecto reutiliza una foto real del sitio (no una imagen 1200×630 dedicada). Una imagen de compartir a medida queda como pulido opcional posterior.