### PR TITLE
content: 'legalización' → 'normalización' en gelco-medida-media-tension

### DIFF
--- a/src/content/proyectos/gelco-medida-media-tension.mdx
+++ b/src/content/proyectos/gelco-medida-media-tension.mdx
@@ -1,15 +1,15 @@
 ---
-title: Legalización de Carga e Instalación de Medida en Media Tensión
+title: Normalización de Carga e Instalación de Medida en Media Tensión
 sector: Alimentos
 cliente: GELCO
 coverImage: "/assets/images/proyectos/gelco-medida-media-tension/cover.jpg"
-resumen: Legalización del aumento de carga de 2.5 a 3.5 MVA e instalación del sistema de medida en media tensión ante el operador, bajo norma RETIE.
+resumen: Normalización del aumento de carga de 2.5 a 3.5 MVA e instalación del sistema de medida en media tensión ante el operador, bajo norma RETIE.
 kpis:
-  - { label: "Carga legalizada", value: "3.5MVA" }
+  - { label: "Carga normalizada", value: "3.5MVA" }
   - { label: "Sistema de medida", value: "Media tensión" }
   - { label: "Cumplimiento", value: "RETIE" }
 tecnologias: ["Sistema de medida en media tensión", "RETIE"]
-tags: ["media tensión", "legalización"]
+tags: ["media tensión", "normalización"]
 destacado: false
 order: 15
 gallery:
@@ -21,14 +21,14 @@ gallery:
 
 ## Reto
 
-El aumento de la carga de consumo de 2.5 a 3.5 MVA no se encontraba legalizado ante el operador de energía.
+El aumento de la carga de consumo de 2.5 a 3.5 MVA no se encontraba normalizado ante el operador de energía.
 
 ## Intervención
 
-- Legalización del aumento de carga de 2.5 a 3.5 MVA ante el operador.
+- Normalización del aumento de carga de 2.5 a 3.5 MVA ante el operador.
 - Instalación del sistema de medida en media tensión bajo la normativa vigente.
 - Cumplimiento de la normativa RETIE.
 
 ## Resultados
 
-Carga legalizada y sistema de medida certificado ante el operador de energía.
+Carga normalizada y sistema de medida certificado ante el operador de energía.


### PR DESCRIPTION
Cambio de terminología pedido por el dueño en el caso de medida en media tensión de GELCO: 'legalización/legalizada/legalizado' → 'normalización/normalizada/normalizado' (título, resumen, KPI, tag y cuerpo). Build OK.