### PR TITLE
feat(chat): globos + escribiendo, persona Sofía, handoff a Sandra y CC de correos

### DIFF
--- a/src/components/nocturne/ChatWidget.astro
+++ b/src/components/nocturne/ChatWidget.astro
@@ -3,7 +3,7 @@
 // (WhatsAppChat.astro). El chat incluye un enlace directo a WhatsApp adentro
 // del panel, así que cubre el mismo caso de uso y suma atención con IA,
 // streaming de respuestas y captura de leads.
-const WHATSAPP_NUMBER = '573006300658';
+const WHATSAPP_NUMBER = '573243025107';
 const WHATSAPP_DEFAULT_TEXT = 'Hola S&G, vengo del chat del sitio web.';
 const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(WHATSAPP_DEFAULT_TEXT)}`;
 ---
@@ -19,8 +19,8 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
     <header class="chat-head">
       <span class="chat-head-dot" aria-hidden="true"></span>
       <div class="chat-head-info">
-        <span class="chat-head-name">Asistente S&amp;G</span>
-        <span class="chat-head-status">En línea</span>
+        <span class="chat-head-name">Sofía · S&amp;G</span>
+        <span class="chat-head-status">Asesora · En línea</span>
       </div>
       <button class="chat-close" id="chat-close" type="button" aria-label="Cerrar chat">&times;</button>
     </header>
@@ -187,27 +187,62 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
     gap: 10px;
     background: var(--paper);
   }
-  .chat-bubble {
-    max-width: 84%;
+  /* Las burbujas se crean por JS (createElement) y NO reciben el scope de
+     Astro, por eso estas reglas van con :global para que se apliquen. */
+  :global(.chat-bubble) {
+    max-width: 82%;
     padding: 10px 13px;
-    border-radius: 12px;
+    border-radius: 14px;
     font-size: 14.5px;
     line-height: 1.5;
     white-space: pre-wrap;
     word-break: break-word;
+    box-shadow: 0 1px 2px rgba(13, 20, 23, 0.08);
+    animation: chat-pop 0.18s ease both;
   }
-  .chat-bubble--bot {
+  :global(.chat-bubble--bot) {
     align-self: flex-start;
     background: #fff;
     border: 1px solid var(--line);
     color: var(--ink);
     border-bottom-left-radius: 4px;
   }
-  .chat-bubble--user {
+  :global(.chat-bubble--user) {
     align-self: flex-end;
     background: var(--teal-700);
     color: #fff;
     border-bottom-right-radius: 4px;
+  }
+  :global(.chat-bubble--typing) {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+    padding: 13px 15px;
+  }
+  :global(.chat-bubble--typing span) {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--muted);
+    animation: chat-dot 1.2s infinite ease-in-out both;
+  }
+  :global(.chat-bubble--typing span:nth-child(2)) {
+    animation-delay: 0.18s;
+  }
+  :global(.chat-bubble--typing span:nth-child(3)) {
+    animation-delay: 0.36s;
+  }
+  @keyframes chat-dot {
+    0%, 80%, 100% { transform: scale(0.7); opacity: 0.4; }
+    40% { transform: scale(1); opacity: 1; }
+  }
+  @keyframes chat-pop {
+    from { opacity: 0; transform: translateY(4px); }
+    to { opacity: 1; transform: none; }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    :global(.chat-bubble) { animation: none; }
+    :global(.chat-bubble--typing span) { animation: none; opacity: 0.6; }
   }
 
   .chat-typing {
@@ -321,8 +356,8 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
 <script is:inline>
   (function () {
     var STORAGE_KEY = 'sg-chat-session-id';
-    var WHATSAPP_NUMBER = '573006300658';
-    var GREETING = '¡Hola! Soy el asistente de S&G. ¿En qué proyecto o proceso te puedo ayudar?';
+    var WHATSAPP_NUMBER = '573243025107';
+    var GREETING = '¡Hola! Soy Sofía, del equipo de S&G. Contame qué proceso querés automatizar, medir o mejorar y te oriento con gusto. 😊';
 
     var widget = document.getElementById('chat-widget');
     var fab = document.getElementById('chat-fab');
@@ -355,12 +390,24 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
 
     var sessionId = getSessionId();
 
+    var userHistory = [];
     function updateWaLink(lastMessage) {
       if (!waLink) return;
-      var text = 'Hola S&G, vengo del chat del sitio web.';
-      if (lastMessage) {
-        text += ' Sobre esto: "' + lastMessage.slice(0, 180) + '"';
+      if (lastMessage) userHistory.push(lastMessage);
+      var joined = userHistory.join(' ');
+      var email = (joined.match(/[\w.+-]+@[\w-]+\.[a-zA-Z]{2,}/) || [])[0];
+      var phone = (joined.match(/(?:\+?57[\s.-]?)?3\d{2}[\s.-]?\d{3}[\s.-]?\d{4}/) || [])[0];
+      var nameM = joined.match(/\b(?:me llamo|mi nombre es|soy)\s+([A-Za-zÁÉÍÓÚÑáéíóúñ]+(?:\s+[A-Za-zÁÉÍÓÚÑáéíóúñ]+){0,2})/i);
+      // Mensaje prellenado para Sandra: resumen de la consulta + datos captados.
+      var text = 'Hola, vengo del chat de la web de S&G y me gustaría que me atienda un asesor.';
+      if (userHistory.length) {
+        text += '\n\nResumen de mi consulta: ' + userHistory.slice(-3).join(' ').slice(0, 300);
       }
+      var info = [];
+      if (nameM) info.push('Nombre: ' + nameM[1]);
+      if (email) info.push('Correo: ' + email);
+      if (phone) info.push('Tel: ' + phone);
+      if (info.length) text += '\n\nMis datos: ' + info.join(' · ');
       waLink.href = 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(text);
     }
 
@@ -371,6 +418,20 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
       messagesEl.appendChild(bubble);
       messagesEl.scrollTop = messagesEl.scrollHeight;
       return bubble;
+    }
+
+    function addTyping() {
+      var bubble = document.createElement('div');
+      bubble.className = 'chat-bubble chat-bubble--bot chat-bubble--typing';
+      bubble.setAttribute('aria-label', 'Sofía está escribiendo');
+      bubble.innerHTML = '<span></span><span></span><span></span>';
+      messagesEl.appendChild(bubble);
+      messagesEl.scrollTop = messagesEl.scrollHeight;
+      return bubble;
+    }
+
+    function sleep(ms) {
+      return new Promise(function (resolve) { setTimeout(resolve, ms); });
     }
 
     function openPanel() {
@@ -436,7 +497,6 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
       isSending = state;
       sendBtn.disabled = state;
       input.disabled = state;
-      typingEl.hidden = !state;
     }
 
     async function sendMessage(text) {
@@ -444,8 +504,21 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
       updateWaLink(text);
       setSending(true);
 
-      var botBubble = addBubble('bot', '');
+      var typingBubble = addTyping();
+      var startedAt = Date.now();
+      var MIN_TYPING = 900;
       var accumulated = '';
+      var revealed = false;
+      var botBubble = null;
+
+      function reveal() {
+        if (revealed) return;
+        revealed = true;
+        if (typingBubble && typingBubble.parentNode) {
+          typingBubble.parentNode.removeChild(typingBubble);
+        }
+        botBubble = addBubble('bot', accumulated);
+      }
 
       try {
         var res = await fetch('/api/chat', {
@@ -463,16 +536,33 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
           var chunk = await reader.read();
           if (chunk.done) break;
           accumulated += decoder.decode(chunk.value, { stream: true });
-          botBubble.textContent = accumulated;
-          messagesEl.scrollTop = messagesEl.scrollHeight;
+          // Mantenemos "Sofía está escribiendo…" al menos MIN_TYPING ms.
+          if (!revealed && accumulated && Date.now() - startedAt >= MIN_TYPING) {
+            reveal();
+          }
+          if (revealed && botBubble) {
+            botBubble.textContent = accumulated;
+            messagesEl.scrollTop = messagesEl.scrollHeight;
+          }
         }
 
-        if (!accumulated) {
-          botBubble.textContent =
-            'No pude generar una respuesta. Escribinos por WhatsApp y te ayudamos enseguida: https://wa.me/' +
-            WHATSAPP_NUMBER;
+        // Respuesta rápida/corta: garantizamos el tiempo mínimo de escritura.
+        if (!revealed) {
+          var remaining = MIN_TYPING - (Date.now() - startedAt);
+          if (remaining > 0) await sleep(remaining);
+          reveal();
         }
+
+        botBubble.textContent =
+          accumulated ||
+          'No pude generar una respuesta. Escribinos por WhatsApp y te ayudamos enseguida: https://wa.me/' +
+            WHATSAPP_NUMBER;
+        messagesEl.scrollTop = messagesEl.scrollHeight;
       } catch (err) {
+        if (typingBubble && typingBubble.parentNode) {
+          typingBubble.parentNode.removeChild(typingBubble);
+        }
+        if (!botBubble) botBubble = addBubble('bot', '');
         botBubble.textContent =
           'Ahora mismo no puedo responder por acá. Escribinos por WhatsApp: https://wa.me/' +
           WHATSAPP_NUMBER +

--- a/src/components/nocturne/Contacto.astro
+++ b/src/components/nocturne/Contacto.astro
@@ -13,6 +13,7 @@
       <ul class="clist rv">
         <li><span class="lb">Ubicación</span><span>Carrera 44 #69-80, Barranquilla, Atlántico, Colombia</span></li>
         <li><span class="lb">Teléfono</span><a href="tel:+573006300658">+57 300 630 0658</a></li>
+        <li><span class="lb">Ventas</span><a href="https://wa.me/573243025107" target="_blank" rel="noopener noreferrer">WhatsApp +57 324 3025107</a></li>
         <li><span class="lb">Correo</span><a href="mailto:comercial.proyectos@sgsolucionesing.com">comercial.proyectos@sgsolucionesing.com</a></li>
       </ul>
     </div>

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -23,15 +23,19 @@ const OPENROUTER_API_KEY = import.meta.env.OPENROUTER_API_KEY ?? process.env.OPE
 const CONTACT_TO = import.meta.env.CONTACT_TO ?? process.env.CONTACT_TO ?? 'comercial.proyectos@sgsolucionesing.com';
 const CONTACT_FROM =
   import.meta.env.CONTACT_FROM ?? process.env.CONTACT_FROM ?? 'S&G Web <web@sgsolucionesing.com>';
+const CONTACT_CC =
+  import.meta.env.CONTACT_CC ?? process.env.CONTACT_CC ?? 'gestion.ofertas@sgsolucionesing.com';
 const RESEND_API_KEY = import.meta.env.RESEND_API_KEY ?? process.env.RESEND_API_KEY;
 
-const WHATSAPP_URL = 'https://wa.me/573006300658';
+const WHATSAPP_URL = 'https://wa.me/573243025107';
 const FALLBACK_MESSAGE = `Ahora mismo no puedo responderte por acá. Escribinos por WhatsApp: ${WHATSAPP_URL} y te atendemos enseguida.`;
 
 const MAX_USER_MESSAGES = 30;
 const MAX_MESSAGE_LENGTH = 2000;
 
-const SYSTEM_PROMPT = `Sos el asistente virtual de S&G Soluciones de Ingeniería, una empresa de ingeniería con sede en Barranquilla, Colombia, especializada en automatización y control industrial, instrumentación, eficiencia energética, diseño y fabricación de tableros eléctricos, montaje eléctrico bajo la norma RETIE y mantenimiento industrial.
+const SYSTEM_PROMPT = `Sos Sofía, asesora del equipo comercial de S&G Soluciones de Ingeniería, una empresa de ingeniería con sede en Barranquilla, Colombia, especializada en automatización y control industrial, instrumentación, eficiencia energética, diseño y fabricación de tableros eléctricos, montaje eléctrico bajo la norma RETIE y mantenimiento industrial.
+
+Hablás en primera persona como Sofía, con calidez y cercanía humana, en tono profesional pero amable (podés usar algún emoji con moderación). Si te preguntan si sos un bot, una máquina o una inteligencia artificial, NO digas que sos un bot, pero TAMPOCO afirmes que sos "una persona real", humana o de carne y hueso (no mientas sobre eso): presentate por tu función, como agente de ventas del backoffice de S&G, encargada de atender a los clientes, recibir su información, despejar sus dudas y necesidades, y encaminarlos con el representante indicado según lo que requieran. Respondé algo como "soy Sofía, del backoffice comercial de S&G; me encargo de atenderte, entender qué necesitás y conectarte con el asesor indicado". Seguí la charla con naturalidad, sin cortarla.
 
 Datos clave de la empresa:
 - Somos Bronze System Integrator de Rockwell Automation.
@@ -40,14 +44,20 @@ Datos clave de la empresa:
 - Atendemos principalmente la Región Caribe de Colombia.
 - Entre nuestros clientes están GELCO, Ultracem, Litoplas, Cabot, Postobón, Ternium, Sempertex y Sonepar.
 - Publicamos 17 casos de éxito en la sección /proyectos del sitio.
-- Contacto: WhatsApp/teléfono +57 300 630 0658, correo comercial.proyectos@sgsolucionesing.com, Carrera 44 #69-80, Barranquilla.
+- Contacto de ventas (WhatsApp): +57 324 3025107 — ahí te atiende Sandra, nuestra asesora comercial, que retoma la conversación con todo el contexto. Teléfono/WhatsApp general: +57 300 630 0658. Correo: comercial.proyectos@sgsolucionesing.com. Dirección: Carrera 44 #69-80, Barranquilla.
 
-Tu objetivo es atender a quien te escribe de forma cálida, humana y profesional: entendé qué necesita, recomendale el servicio o caso de éxito más relevante para su situación, y llevá la charla hacia una cotización o un contacto directo con el equipo. Pedí nombre y un dato de contacto (correo o teléfono) de forma natural, solo cuando ya se note interés real — nunca en el primer mensaje.
+Pensá SIEMPRE en psicología de venta, confianza y atracción de clientes, con venta consultiva (nunca insistente ni agresiva):
+- Primero generá confianza y entendé la necesidad real: hacé una o dos preguntas breves sobre su proceso, planta o problema antes de recomendar.
+- Usá prueba social y autoridad de forma natural: mencioná casos o clientes reales parecidos ("hicimos algo similar para una planta de alimentos") y credenciales (Bronze Partner de Rockwell, cumplimiento RETIE) para dar seguridad.
+- Traducí lo técnico en beneficios que le importan al cliente: más disponibilidad, menos paradas, ahorro de energía, cumplimiento normativo, procesos visibles en tiempo real.
+- Creá interés y proponé un siguiente paso concreto: una asesoría o cotización sin costo, y llevá la charla hacia dejar sus datos o pasar a WhatsApp. Pedí nombre y un dato de contacto (correo o teléfono) de forma natural SOLO cuando ya se note interés real, nunca en el primer mensaje.
+- Sé genuina y cercana; no exageres, no prometas de más y no presiones.
 
-Reglas que debés respetar siempre:
-- Hablá solo de S&G, sus servicios, sus casos de éxito y su industria (automatización, energía, tableros eléctricos, mantenimiento). Si te preguntan algo fuera de este tema, redirigí la charla amablemente hacia cómo podemos ayudar.
-- Nunca inventes precios, plazos ni datos técnicos que no tengas certeza de conocer. Si no podés responder algo técnico con seguridad, ofrecé conectar con el equipo por WhatsApp: +57 300 630 0658.
-- Respuestas concisas, de 2 a 5 frases, sin markdown pesado (nada de títulos, tablas ni bloques de código).`;
+Reglas que debés respetar siempre (son innegociables):
+- SOLO podés responder preguntas sobre S&G apoyándote en la información de esta empresa: sus servicios, casos de éxito, diferenciadores (Rockwell Bronze, MioBox, RETIE), industria y datos de contacto listados arriba, más lo que está publicado en el sitio. No respondas absolutamente nada fuera de ese alcance.
+- Si te preguntan algo que NO esté cubierto por esa información —un detalle técnico específico que no tengas, precios, plazos, disponibilidad, una cotización puntual, o cualquier tema ajeno a S&G— NO improvises ni inventes: derivá con amabilidad al WhatsApp de ventas +57 324 3025107, explicando que ahí Sandra, nuestra asesora, retoma la conversación con todo el contexto y lo resuelve mejor. Ante la duda de si algo está dentro del alcance, derivá a ese WhatsApp.
+- Nunca inventes precios, plazos ni datos técnicos.
+- Respuestas concisas, de 2 a 5 frases, en español, sin markdown pesado (nada de títulos, tablas ni bloques de código).`;
 
 const EMAIL_RE = /[\w.+-]+@[\w-]+\.[a-zA-Z]{2,}/;
 // Celular colombiano: opcional +57, luego 3XX seguido de 7 dígitos más (con
@@ -95,6 +105,7 @@ async function notifyLead(sessionId: string, lead: LeadInfo, history: ChatMessag
     const { error } = await resend.emails.send({
       from: CONTACT_FROM,
       to: CONTACT_TO,
+      cc: CONTACT_CC,
       subject: `Nuevo lead del chat web${lead.name ? `: ${lead.name}` : ''}`,
       text: `Se detectó un posible lead en el chat del sitio.
 
@@ -193,7 +204,7 @@ export const POST: APIRoute = async ({ request }) => {
         model: OPENROUTER_MODEL,
         stream: true,
         messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...updatedHistory],
-        max_tokens: 1500,
+        max_tokens: 2000,
         temperature: 0.5
       })
     });

--- a/src/pages/api/contacto.ts
+++ b/src/pages/api/contacto.ts
@@ -13,6 +13,7 @@ const CONTACT_TO = import.meta.env.CONTACT_TO ?? 'comercial.proyectos@sgsolucion
 // El dominio de este remitente debe estar verificado en Resend (registros
 // DNS en Cloudflare) o el envío falla. Ver runbook de despliegue en el PR.
 const CONTACT_FROM = import.meta.env.CONTACT_FROM ?? 'S&G Web <web@sgsolucionesing.com>';
+const CONTACT_CC = import.meta.env.CONTACT_CC ?? 'gestion.ofertas@sgsolucionesing.com';
 
 const contactoSchema = z.object({
   nombre: z.string().trim().min(2, 'Muy corto').max(120, 'Muy largo'),
@@ -67,6 +68,7 @@ export const POST: APIRoute = async ({ request }) => {
     const { error } = await resend.emails.send({
       from: CONTACT_FROM,
       to: CONTACT_TO,
+      cc: CONTACT_CC,
       replyTo: correo,
       subject: `Nuevo contacto web: ${nombre}`,
       text: `Nombre: ${nombre}\nCorreo: ${correo}\n\nMensaje:\n${mensaje}`,


### PR DESCRIPTION
Mejoras de UX y comportamiento del chat con IA, pedidas por el dueño.

- **Globos de chat**: fix del bug de estilos (Astro scopea el `<style>` pero las burbujas se crean por JS y no recibían el scope → ahora `:global`). Usuario a la derecha (teal), Sofía a la izquierda (blanco).
- **'Escribiendo…'** con puntos animados dentro de una burbuja + **delay mínimo** antes de revelar (se siente humano; el modelo de razonamiento ya agrega latencia natural).
- **Persona 'Sofía'** (asesora de backoffice comercial): nombre en header, saludo y prompt. **Psicología de venta consultiva** (confianza, prueba social, autoridad, beneficios, siguiente paso, sin presionar). Si le preguntan si es bot, no lo dice ni afirma ser persona real: se presenta por su rol.
- **Guardrail estricto**: solo responde temas de S&G con la info de la empresa/el sitio; fuera de eso deriva a WhatsApp.
- **Handoff a Sandra**: el chat deriva a **+57 324 3025107** (Sandra) con **resumen de la consulta + datos del usuario** prellenados. Ese número se agrega como **contacto de ventas** en la sección Contacto.
- **CC de correos**: lead del chat y formulario de contacto salen con copia a **gestion.ofertas@sgsolucionesing.com** (`CONTACT_CC`, env-overridable).
- `max_tokens` 1500→2000 (deepseek-v4-flash es de razonamiento y dejaba respuestas vacías).

Verificado en local contra el gateway real: burbujas globales en el CSS, handoff a 324, persona correcta, guardrail y build OK.