### PR TITLE
feat(chat): número único +57 324 3025107, detector robusto y levantamiento de alcance

### DIFF
--- a/src/components/nocturne/ChatWidget.astro
+++ b/src/components/nocturne/ChatWidget.astro
@@ -5,7 +5,7 @@
 // streaming de respuestas y captura de leads.
 const WHATSAPP_NUMBER = '573243025107';
 const WHATSAPP_DEFAULT_TEXT = 'Hola S&G, vengo del chat del sitio web.';
-const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponent(WHATSAPP_DEFAULT_TEXT)}`;
+const waDefaultLink = `https://api.whatsapp.com/send?phone=${WHATSAPP_NUMBER}&text=${encodeURIComponent(WHATSAPP_DEFAULT_TEXT)}`;
 ---
 
 <div class="chat-widget" id="chat-widget">
@@ -422,10 +422,14 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
       return text;
     }
 
+    function waLinkFor(text) {
+      return 'https://api.whatsapp.com/send?phone=' + WHATSAPP_NUMBER + '&text=' + encodeURIComponent(text);
+    }
+
     function updateWaLink(lastMessage) {
       if (!waLink) return;
       if (lastMessage) userHistory.push(lastMessage);
-      waLink.href = 'https://wa.me/' + WHATSAPP_NUMBER + '?text=' + encodeURIComponent(buildWaText());
+      waLink.href = waLinkFor(buildWaText());
     }
 
     function escapeHtml(s) {
@@ -438,12 +442,12 @@ const waDefaultLink = `https://wa.me/${WHATSAPP_NUMBER}?text=${encodeURIComponen
     function formatBotHtml(raw) {
       var s = escapeHtml(raw || '');
       s = s.replace(/\*\*([^*]+)\*\*/g, '<strong>$1</strong>');
-      var waSandra = 'https://wa.me/573243025107?text=' + encodeURIComponent(buildWaText());
+      var waSandra = waLinkFor(buildWaText());
       var attrs = ' target="_blank" rel="noopener noreferrer"';
-      var re = /(\+?57[\s.-]?324[\s.-]?3025107|573243025107|wa\.me\/573243025107)|(\+?57[\s.-]?300[\s.-]?630[\s.-]?0658|573006300658)|([\w.+-]+@[\w-]+\.[a-zA-Z]{2,})|(https?:\/\/[^\s<]+)/g;
-      return s.replace(re, function (m, sandra, general, email, url) {
+      // Detecta el número (con o sin +57 y con cualquier separador), correos y URLs.
+      var re = /((?:\+?57[\s.-]?)?324[\s.-]?302[\s.-]?5107|573243025107|3243025107|wa\.me\/573243025107)|([\w.+-]+@[\w-]+\.[a-zA-Z]{2,})|(https?:\/\/[^\s<]+)/g;
+      return s.replace(re, function (m, sandra, email, url) {
         if (sandra) return '<a href="' + waSandra + '"' + attrs + '>' + m + '</a>';
-        if (general) return '<a href="https://wa.me/573006300658"' + attrs + '>' + m + '</a>';
         if (email) return '<a href="mailto:' + m + '">' + m + '</a>';
         if (url) return '<a href="' + m + '"' + attrs + '>' + m + '</a>';
         return m;

--- a/src/components/nocturne/Contacto.astro
+++ b/src/components/nocturne/Contacto.astro
@@ -12,8 +12,7 @@
       </p>
       <ul class="clist rv">
         <li><span class="lb">Ubicación</span><span>Carrera 44 #69-80, Barranquilla, Atlántico, Colombia</span></li>
-        <li><span class="lb">Teléfono</span><a href="tel:+573006300658">+57 300 630 0658</a></li>
-        <li><span class="lb">Ventas</span><a href="https://wa.me/573243025107" target="_blank" rel="noopener noreferrer">WhatsApp +57 324 3025107</a></li>
+        <li><span class="lb">Teléfono / WhatsApp</span><a href="https://wa.me/573243025107" target="_blank" rel="noopener noreferrer">+57 324 3025107</a></li>
         <li><span class="lb">Correo</span><a href="mailto:comercial.proyectos@sgsolucionesing.com">comercial.proyectos@sgsolucionesing.com</a></li>
       </ul>
     </div>
@@ -77,13 +76,13 @@
         form.reset();
       } else {
         setMessage(
-          'No pudimos enviar tu mensaje, escríbenos por WhatsApp mientras tanto: https://wa.me/573006300658',
+          'No pudimos enviar tu mensaje, escríbenos por WhatsApp mientras tanto: https://wa.me/573243025107',
           'error'
         );
       }
     } catch {
       setMessage(
-        'No pudimos enviar tu mensaje, escríbenos por WhatsApp mientras tanto: https://wa.me/573006300658',
+        'No pudimos enviar tu mensaje, escríbenos por WhatsApp mientras tanto: https://wa.me/573243025107',
         'error'
       );
     } finally {

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -44,7 +44,7 @@ Datos clave de la empresa:
 - Atendemos principalmente la Región Caribe de Colombia.
 - Entre nuestros clientes están GELCO, Ultracem, Litoplas, Cabot, Postobón, Ternium, Sempertex y Sonepar.
 - Publicamos 17 casos de éxito en la sección /proyectos del sitio.
-- Contacto de ventas (WhatsApp): +57 324 3025107 — ahí te atiende Sandra, nuestra asesora comercial, que retoma la conversación con todo el contexto. Teléfono/WhatsApp general: +57 300 630 0658. Correo: comercial.proyectos@sgsolucionesing.com. Dirección: Carrera 44 #69-80, Barranquilla.
+- Contacto único (WhatsApp/teléfono): +57 324 3025107 — ahí te atiende Sandra, nuestra asesora comercial, que retoma la conversación con todo el contexto. Correo: comercial.proyectos@sgsolucionesing.com. Dirección: Carrera 44 #69-80, Barranquilla. Cuando compartas el número, escribilo SIEMPRE completo así: +57 324 3025107.
 
 Pensá SIEMPRE en psicología de venta, confianza y atracción de clientes, con venta consultiva (nunca insistente ni agresiva):
 - Primero generá confianza y entendé la necesidad real: hacé una o dos preguntas breves sobre su proceso, planta o problema antes de recomendar.
@@ -52,6 +52,15 @@ Pensá SIEMPRE en psicología de venta, confianza y atracción de clientes, con 
 - Traducí lo técnico en beneficios que le importan al cliente: más disponibilidad, menos paradas, ahorro de energía, cumplimiento normativo, procesos visibles en tiempo real.
 - Creá interés y proponé un siguiente paso concreto: una asesoría o cotización sin costo, y llevá la charla hacia dejar sus datos o pasar a WhatsApp. Pedí nombre y un dato de contacto (correo o teléfono) de forma natural SOLO cuando ya se note interés real, nunca en el primer mensaje.
 - Sé genuina y cercana; no exageres, no prometas de más y no presiones.
+
+Mostrá SIEMPRE interés genuino por entender bien el caso del cliente y enriquecé la definición del alcance con preguntas pertinentes, de a poco y con naturalidad (una o dos por mensaje, nunca como formulario). Según el tipo de solicitud, indagá sobre:
+- La necesidad y el objetivo real: qué problema busca resolver y qué espera lograr.
+- Marcas o tecnologías de su preferencia, si el cliente las valora (p. ej. Allen Bradley, Siemens, Schneider).
+- Cantidades, potencias y medidas: HP de los motores, kVA/MVA, número de tableros o equipos, calibres.
+- Distancias y metrajes: longitud de cableado o de los tramos, ubicación y separación de los equipos.
+- Condiciones ambientales del sitio: temperatura, humedad, polvo, ambiente corrosivo, intemperie o zona clasificada.
+- Estado actual y contexto: qué existe hoy, qué se quiere conservar o reemplazar, plazos o urgencias.
+Con esos datos se define mejor el alcance para dar una asesoría acertada; cuando haya interés, coordinás la atención con Sandra por WhatsApp (+57 324 3025107).
 
 Reglas que debés respetar siempre (son innegociables):
 - SOLO podés responder preguntas sobre S&G apoyándote en la información de esta empresa: sus servicios, casos de éxito, diferenciadores (Rockwell Bronze, MioBox, RETIE), industria y datos de contacto listados arriba, más lo que está publicado en el sitio. No respondas absolutamente nada fuera de ese alcance.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -22,7 +22,7 @@ const pageDescription =
     image: 'https://www.sgsolucionesing.com/assets/img/pruebas-1.jpg',
     description:
       'Empresa de ingeniería especializada en automatización industrial, Industria 4.0/IoT, gestión y calidad de energía, y desarrollo de software a la medida para la industria de la Región Caribe de Colombia.',
-    telephone: '+573006300658',
+    telephone: '+573243025107',
     email: 'comercial.proyectos@sgsolucionesing.com',
     address: {
       '@type': 'PostalAddress',


### PR DESCRIPTION
- **Número único de contacto**: todo el sitio a +57 324 3025107 (Sandra); se elimina el 300 630 0658.
- **Detector de número robusto** en el chat: linkifica el número aunque el bot lo escriba sin +57 (era la causa de que 'no pasara nada' al tocarlo). Enlaces con formato `api.whatsapp.com/send` (prellenado más confiable del resumen).
- **Levantamiento de alcance**: Sofía muestra interés y pregunta necesidad, marca (si el cliente la valora), cantidades/potencias, distancias/metraje y condiciones ambientales, con psicología de venta.

Nota: el modelo `deepseek-v4-flash` resultó inservible (razona hasta consumir todo el presupuesto → respuestas vacías en consultas técnicas). Se cambia por env a `deepseek-v4-pro` (misma familia, confiable).