### PR TITLE
fix(chat): flash con ventana amplia + Sandra contacto comercial + resumen completo a WhatsApp

### DIFF
--- a/src/components/nocturne/ChatWidget.astro
+++ b/src/components/nocturne/ChatWidget.astro
@@ -404,15 +404,21 @@ const waDefaultLink = `https://api.whatsapp.com/send?phone=${WHATSAPP_NUMBER}&te
 
     var userHistory = [];
 
-    // Arma el texto prellenado para WhatsApp: resumen de la consulta + datos captados.
+    // Arma el texto prellenado para WhatsApp: resumen COMPLETO de la consulta +
+    // datos captados, para que Sandra retome con todo el contexto sin que el
+    // cliente tenga que volver a explicar nada.
     function buildWaText() {
       var joined = userHistory.join(' ');
       var email = (joined.match(/[\w.+-]+@[\w-]+\.[a-zA-Z]{2,}/) || [])[0];
       var phone = (joined.match(/(?:\+?57[\s.-]?)?3\d{2}[\s.-]?\d{3}[\s.-]?\d{4}/) || [])[0];
       var nameM = joined.match(/\b(?:me llamo|mi nombre es|soy)\s+([A-Za-zÁÉÍÓÚÑáéíóúñ]+(?:\s+[A-Za-zÁÉÍÓÚÑáéíóúñ]+){0,2})/i);
-      var text = 'Hola, vengo del chat de la web de S&G y me gustaría que me atienda un asesor.';
+      var text = 'Hola, vengo del chat de la web de S&G. Este es el resumen de mi consulta para que puedan retomarla:';
       if (userHistory.length) {
-        text += '\n\nResumen de mi consulta: ' + userHistory.slice(-3).join(' ').slice(0, 300);
+        // Incluimos toda la consulta del cliente (no solo los últimos mensajes),
+        // en viñetas, con un tope amplio para no exceder el límite del enlace.
+        var recap = userHistory.map(function (m) { return '• ' + m.trim(); }).join('\n');
+        if (recap.length > 1200) recap = recap.slice(0, 1200) + '…';
+        text += '\n\n' + recap;
       }
       var info = [];
       if (nameM) info.push('Nombre: ' + nameM[1]);

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -19,6 +19,13 @@ const OPENROUTER_BASE_URL =
 const OPENROUTER_MODEL =
   import.meta.env.OPENROUTER_MODEL ?? process.env.OPENROUTER_MODEL ?? 'openai/gpt-4o-mini';
 const OPENROUTER_API_KEY = import.meta.env.OPENROUTER_API_KEY ?? process.env.OPENROUTER_API_KEY;
+// Tope de tokens por respuesta. deepseek-v4-flash es un modelo de razonamiento:
+// consume tokens "pensando" (reasoning_content) antes de emitir la respuesta.
+// Si el tope es bajo, el razonamiento se lo come entero y la respuesta llega
+// vacía. Damos ventana amplia (configurable) para que siempre alcance a responder.
+const OPENROUTER_MAX_TOKENS = Number(
+  import.meta.env.OPENROUTER_MAX_TOKENS ?? process.env.OPENROUTER_MAX_TOKENS ?? 6000
+);
 
 const CONTACT_TO = import.meta.env.CONTACT_TO ?? process.env.CONTACT_TO ?? 'comercial.proyectos@sgsolucionesing.com';
 const CONTACT_FROM =
@@ -44,7 +51,7 @@ Datos clave de la empresa:
 - Atendemos principalmente la Región Caribe de Colombia.
 - Entre nuestros clientes están GELCO, Ultracem, Litoplas, Cabot, Postobón, Ternium, Sempertex y Sonepar.
 - Publicamos 17 casos de éxito en la sección /proyectos del sitio.
-- Contacto único (WhatsApp/teléfono): +57 324 3025107 — ahí te atiende Sandra, nuestra asesora comercial, que retoma la conversación con todo el contexto. Correo: comercial.proyectos@sgsolucionesing.com. Dirección: Carrera 44 #69-80, Barranquilla. Cuando compartas el número, escribilo SIEMPRE completo así: +57 324 3025107.
+- Contacto único (WhatsApp/teléfono): +57 324 3025107 — ahí te atiende Sandra, nuestro contacto comercial, que ya recibe el resumen de esta conversación y retoma desde donde vamos, sin que tengas que repetir nada. Correo: comercial.proyectos@sgsolucionesing.com. Dirección: Carrera 44 #69-80, Barranquilla. Cuando compartas el número, escribilo SIEMPRE completo así: +57 324 3025107.
 
 Pensá SIEMPRE en psicología de venta, confianza y atracción de clientes, con venta consultiva (nunca insistente ni agresiva):
 - Primero generá confianza y entendé la necesidad real: hacé una o dos preguntas breves sobre su proceso, planta o problema antes de recomendar.
@@ -64,7 +71,7 @@ Con esos datos se define mejor el alcance para dar una asesoría acertada; cuand
 
 Reglas que debés respetar siempre (son innegociables):
 - SOLO podés responder preguntas sobre S&G apoyándote en la información de esta empresa: sus servicios, casos de éxito, diferenciadores (Rockwell Bronze, MioBox, RETIE), industria y datos de contacto listados arriba, más lo que está publicado en el sitio. No respondas absolutamente nada fuera de ese alcance.
-- Si te preguntan algo que NO esté cubierto por esa información —un detalle técnico específico que no tengas, precios, plazos, disponibilidad, una cotización puntual, o cualquier tema ajeno a S&G— NO improvises ni inventes: derivá con amabilidad al WhatsApp de ventas +57 324 3025107, explicando que ahí Sandra, nuestra asesora, retoma la conversación con todo el contexto y lo resuelve mejor. Ante la duda de si algo está dentro del alcance, derivá a ese WhatsApp.
+- Si te preguntan algo que NO esté cubierto por esa información —un detalle técnico específico que no tengas, precios, plazos, disponibilidad, una cotización puntual, o cualquier tema ajeno a S&G— NO improvises ni inventes: derivá con amabilidad al WhatsApp de ventas +57 324 3025107, explicando que ahí Sandra, nuestro contacto comercial, ya recibe el resumen de esta conversación y retoma desde donde vamos —sin que el cliente tenga que volver a explicar nada— y lo resuelve mejor. Ante la duda de si algo está dentro del alcance, derivá a ese WhatsApp.
 - Nunca inventes precios, plazos ni datos técnicos.
 - Respondé SIEMPRE en el mismo idioma en que te escriba el visitante: si escribe en inglés, respondé en inglés; en portugués, en portugués; y así con cualquier idioma. Por defecto, español.
 - Respuestas concisas, de 2 a 5 frases, en el idioma del visitante, sin markdown pesado (nada de títulos, tablas ni bloques de código).`;
@@ -214,7 +221,7 @@ export const POST: APIRoute = async ({ request }) => {
         model: OPENROUTER_MODEL,
         stream: true,
         messages: [{ role: 'system', content: SYSTEM_PROMPT }, ...updatedHistory],
-        max_tokens: 2000,
+        max_tokens: OPENROUTER_MAX_TOKENS,
         temperature: 0.5
       })
     });


### PR DESCRIPTION
## Respuestas vacías (raíz)
`deepseek-v4-flash` es un modelo de **razonamiento**: gasta ~500 tokens 'pensando' antes de emitir la respuesta. Con `max_tokens: 2000`, en consultas técnicas el razonamiento se comía todo el presupuesto y la respuesta llegaba **vacía**. 

**Fix:** `max_tokens` configurable por env `OPENROUTER_MAX_TOKENS` (default 6000). En producción se despliega con **10000**. Verificado: flash con ventana amplia responde con content real + hace el descubrimiento consultivo.

## Sandra
- 'nuestra asesora' → **'nuestro contacto comercial'** en el prompt.
- El prompt aclara que Sandra **ya recibe el resumen** y retoma sin que el cliente repita nada.

## Garantía de contexto a WhatsApp
- `buildWaText` arma un **resumen completo** de la consulta (toda la conversación del cliente, en viñetas, tope 1200 chars) + datos captados (nombre/correo/tel). Al tocar el botón, el mensaje prellenado que el cliente envía ya lleva todo el contexto.