### PR TITLE
fix(hero): el logo del nav ya no se pisa con la línea superior del hero

### DIFF
--- a/src/styles/nocturne.css
+++ b/src/styles/nocturne.css
@@ -58,7 +58,10 @@ h1,h2,h3,h4{font-family:var(--cond);font-weight:600;margin:0;letter-spacing:-0.0
     .nav #nav-menu{transition:none}
   }
 }
-.hero{min-height:100vh;display:flex;flex-direction:column;justify-content:flex-end;color:#fff;padding:0 var(--edge) clamp(40px,5vw,72px);position:relative;overflow:hidden;background:var(--ink)}
+/* padding-top reserva el alto del nav fijo (~70px) para que la línea superior
+   del hero (.kick) no se pise con el logo. Con min-height (no alto fijo) el
+   contenido crece si hace falta y nunca se recorta. */
+.hero{min-height:100vh;display:flex;flex-direction:column;justify-content:flex-end;color:#fff;padding:clamp(92px,12vh,132px) var(--edge) clamp(40px,5vw,72px);position:relative;overflow:hidden;background:var(--ink)}
 .hero .bg{position:absolute;inset:0;z-index:0}
 .hero .bg img{width:100%;height:100%;object-fit:cover;transform:scale(1.06);animation:kb 18s ease-out forwards}
 @keyframes kb{to{transform:scale(1)}}


### PR DESCRIPTION
En viewports donde el contenido del hero es alto, la línea superior (`.kick` — 'Automatización · Instrumentación · Eficiencia Energética') subía hasta el borde y se **pisaba con el logo** del nav fijo.

**Causa:** `.hero` usa `justify-content:flex-end` con `padding-top:0`; el nav es `position:fixed` transparente encima, sin espacio reservado.

**Fix:** `padding-top: clamp(92px,12vh,132px)` en `.hero` para reservar el alto del nav. Como el hero es `min-height:100vh` (no alto fijo), el contenido crece si hace falta y nunca se recorta.