### PR TITLE
feat(home): franja de certificaciones (Servimeters + ISO 9001 Bureau Veritas)

### DIFF
--- a/src/components/PageHome.astro
+++ b/src/components/PageHome.astro
@@ -8,6 +8,7 @@ import Servicios from './nocturne/Servicios.astro';
 import Casos from './nocturne/Casos.astro';
 import Clientes from './nocturne/Clientes.astro';
 import Nosotros from './nocturne/Nosotros.astro';
+import Certificaciones from './nocturne/Certificaciones.astro';
 import Testimonios from './nocturne/Testimonios.astro';
 import Contacto from './nocturne/Contacto.astro';
 import { ui, getLang } from '../i18n/ui';
@@ -67,6 +68,7 @@ const jsonld = {
   <Casos />
   <Clientes />
   <Nosotros />
+  <Certificaciones />
   <Testimonios />
   <Contacto />
 </BaseLayout>

--- a/src/components/nocturne/Certificaciones.astro
+++ b/src/components/nocturne/Certificaciones.astro
@@ -1,0 +1,43 @@
+---
+// src/components/nocturne/Certificaciones.astro
+// Franja de certificaciones (sellos de respaldo). Bilingüe ES/EN.
+import { ui, getLang } from '../../i18n/ui';
+const lang = getLang(Astro.currentLocale);
+const t = ui[lang].certificaciones;
+
+// Sellos oficiales opcionales: colocá el archivo en public/assets/certificaciones/
+// y poné el nombre acá por índice (mismo orden que t.items). Vacío => se usa el
+// badge con ícono. Ej.: ['servimeters.png', 'bureau-veritas-iso9001.png'].
+const seals = ['', ''];
+---
+<section class="certs" id="certificaciones">
+  <div class="wrap">
+    <p class="kick rv">{t.kick}</p>
+    <h2 class="rv">{t.title}</h2>
+    <p class="lead rv">{t.lead}</p>
+    <div class="cert-grid rv">
+      {t.items.map((c, i) => (
+        <article class="cert">
+          <div class="cert-seal">
+            {seals[i] ? (
+              <img src={`/assets/certificaciones/${seals[i]}`} alt={`${c.title} — ${c.issuer}`} loading="lazy" decoding="async" />
+            ) : i === 0 ? (
+              <svg viewBox="0 0 24 24" width="42" height="42" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z" />
+              </svg>
+            ) : (
+              <svg viewBox="0 0 24 24" width="42" height="42" aria-hidden="true" focusable="false">
+                <path fill="currentColor" d="M23,12L20.56,9.22L20.9,5.54L17.29,4.72L15.4,1.54L12,3L8.6,1.54L6.71,4.72L3.1,5.53L3.44,9.21L1,12L3.44,14.78L3.1,18.46L6.71,19.28L8.6,22.46L12,21L15.4,22.46L17.29,19.28L20.9,18.47L20.56,14.78L23,12M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z" />
+              </svg>
+            )}
+          </div>
+          <div class="cert-body">
+            <h3>{c.title}</h3>
+            <p class="cert-issuer">{c.issuer}</p>
+            <p class="cert-desc">{c.desc}</p>
+          </div>
+        </article>
+      ))}
+    </div>
+  </div>
+</section>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -175,6 +175,15 @@ export const ui = {
         { n: 'MIOBOX', l: 'Plataforma IIoT propia' },
       ],
     },
+    certificaciones: {
+      kick: 'Certificaciones',
+      title: 'Respaldo que da confianza.',
+      lead: 'Nuestra capacidad técnica y nuestros procesos están respaldados por certificaciones de terceros.',
+      items: [
+        { title: 'Tableristas certificados', issuer: 'Servimeters', desc: 'Diseño y fabricación de tableros eléctricos bajo certificación.' },
+        { title: 'ISO 9001', issuer: 'Bureau Veritas', desc: 'Sistema de gestión de calidad de nuestros procesos, certificado en 2026.' },
+      ],
+    },
     testimonios: {
       ariaLabel: 'Testimonios',
       dotLabel: 'Testimonio',
@@ -387,6 +396,15 @@ export const ui = {
         { n: '8', l: 'Service lines' },
         { n: 'RA Bronze', l: 'Rockwell Automation partner' },
         { n: 'MIOBOX', l: 'Our own IIoT platform' },
+      ],
+    },
+    certificaciones: {
+      kick: 'Certifications',
+      title: 'Backing you can trust.',
+      lead: 'Our technical capability and processes are backed by third-party certifications.',
+      items: [
+        { title: 'Certified panel builders', issuer: 'Servimeters', desc: 'Design and manufacturing of electrical panels under certification.' },
+        { title: 'ISO 9001', issuer: 'Bureau Veritas', desc: 'Quality management system certified in 2026 across our processes.' },
       ],
     },
     testimonios: {

--- a/src/styles/nocturne.css
+++ b/src/styles/nocturne.css
@@ -321,3 +321,15 @@ footer.site .brand .n{font-family:var(--cond);font-weight:700;letter-spacing:.03
 .clientes .logo-img{height:clamp(28px,3.2vw,38px);width:auto;max-width:150px;object-fit:contain;filter:grayscale(1) opacity(.65);transition:filter .18s;display:block}
 .clientes .logo-img:hover{filter:none;opacity:1}
 @media(max-width:640px){.clientes .logos{gap:16px 28px}.clientes .logo-img{height:clamp(24px,7vw,32px)}}
+
+/* --- Certificaciones (sellos de respaldo) --- */
+.certs{padding:clamp(48px,6vw,84px) 0;border-top:1px solid var(--line)}
+.certs .lead{max-width:60ch;color:var(--muted);margin:10px 0 0}
+.cert-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(300px,1fr));gap:18px;margin-top:32px}
+.cert{display:flex;gap:16px;align-items:flex-start;padding:22px 24px;background:#fff;border:1px solid var(--line);border-radius:12px;transition:border-color .18s,box-shadow .18s}
+.cert:hover{border-color:var(--teal);box-shadow:0 8px 24px rgba(13,20,23,.08)}
+.cert-seal{flex:none;width:64px;height:64px;display:flex;align-items:center;justify-content:center;border-radius:50%;background:rgba(0,167,157,.10);color:var(--teal-700)}
+.cert-seal img{max-width:60px;max-height:60px;object-fit:contain}
+.cert-body h3{font-family:var(--cond);font-weight:600;font-size:21px;letter-spacing:.01em;margin:0;color:var(--ink)}
+.cert-issuer{font-family:var(--cond);font-weight:600;font-size:13.5px;letter-spacing:.05em;text-transform:uppercase;color:var(--teal-700);margin:3px 0 0}
+.cert-desc{color:var(--muted);margin:8px 0 0;font-size:14px;line-height:1.5}


### PR DESCRIPTION
Nueva sección **Certificaciones** en el home (bilingüe ES/EN), tras Nosotros:
- **Tableristas certificados** — Servimeters.
- **ISO 9001** — Bureau Veritas (certificados en 2026).

Badges profesionales con ícono + texto (el dato es real y legítimo). **Preparado para el sello oficial**: dejando el PNG/SVG en `public/assets/certificaciones/` y su nombre en `seals` de `Certificaciones.astro`, el ícono se reemplaza por la imagen.

Nota: los sellos oficiales de Bureau Veritas/Servimeters son marcas de certificación controladas; conviene usar el archivo que entrega el certificador (con el nº de certificado y sus reglas de uso), no una imagen genérica de internet.