### PR TITLE
feat(home): RA Bronze (Rockwell) como tercer sello de certificaciones

### DIFF
--- a/src/components/nocturne/Certificaciones.astro
+++ b/src/components/nocturne/Certificaciones.astro
@@ -1,14 +1,21 @@
 ---
 // src/components/nocturne/Certificaciones.astro
-// Franja de certificaciones (sellos de respaldo). Bilingüe ES/EN.
+// Franja de certificaciones y credenciales (sellos de respaldo). Bilingüe ES/EN.
 import { ui, getLang } from '../../i18n/ui';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].certificaciones;
 
 // Sellos oficiales opcionales: colocá el archivo en public/assets/certificaciones/
-// y poné el nombre acá por índice (mismo orden que t.items). Vacío => se usa el
-// badge con ícono. Ej.: ['servimeters.png', 'bureau-veritas-iso9001.png'].
-const seals = ['', ''];
+// y poné el nombre acá por índice (mismo orden que t.items). Vacío => badge con
+// ícono. Ej.: ['servimeters.png', 'bureau-veritas-iso9001.png', 'ra-bronze.png'].
+const seals = ['', '', ''];
+
+// Ícono por índice (mdi): shield-check, check-decagram, medal.
+const iconPaths = [
+  'M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z',
+  'M23,12L20.56,9.22L20.9,5.54L17.29,4.72L15.4,1.54L12,3L8.6,1.54L6.71,4.72L3.1,5.53L3.44,9.21L1,12L3.44,14.78L3.1,18.46L6.71,19.28L8.6,22.46L12,21L15.4,22.46L17.29,19.28L20.9,18.47L20.56,14.78L23,12M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z',
+  'M20,2H4V4L9.81,8.36C6.14,9.57 4.14,13.53 5.35,17.19C6.56,20.86 10.5,22.86 14.19,21.65C17.86,20.44 19.86,16.5 18.65,12.81C17.95,10.71 16.3,9.06 14.19,8.36L20,4V2M14.94,19.5L12,17.78L9.06,19.5L9.84,16.17L7.25,13.93L10.66,13.64L12,10.5L13.34,13.64L16.75,13.93L14.16,16.17L14.94,19.5Z',
+];
 ---
 <section class="certs" id="certificaciones">
   <div class="wrap">
@@ -21,13 +28,9 @@ const seals = ['', ''];
           <div class="cert-seal">
             {seals[i] ? (
               <img src={`/assets/certificaciones/${seals[i]}`} alt={`${c.title} — ${c.issuer}`} loading="lazy" decoding="async" />
-            ) : i === 0 ? (
-              <svg viewBox="0 0 24 24" width="42" height="42" aria-hidden="true" focusable="false">
-                <path fill="currentColor" d="M12,1L3,5V11C3,16.55 6.84,21.74 12,23C17.16,21.74 21,16.55 21,11V5L12,1M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z" />
-              </svg>
             ) : (
               <svg viewBox="0 0 24 24" width="42" height="42" aria-hidden="true" focusable="false">
-                <path fill="currentColor" d="M23,12L20.56,9.22L20.9,5.54L17.29,4.72L15.4,1.54L12,3L8.6,1.54L6.71,4.72L3.1,5.53L3.44,9.21L1,12L3.44,14.78L3.1,18.46L6.71,19.28L8.6,22.46L12,21L15.4,22.46L17.29,19.28L20.9,18.47L20.56,14.78L23,12M10,17L6,13L7.41,11.59L10,14.17L16.59,7.58L18,9L10,17Z" />
+                <path fill="currentColor" d={iconPaths[i] || iconPaths[0]} />
               </svg>
             )}
           </div>

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -182,6 +182,7 @@ export const ui = {
       items: [
         { title: 'Tableristas certificados', issuer: 'Servimeters', desc: 'Diseño y fabricación de tableros eléctricos bajo certificación.' },
         { title: 'ISO 9001', issuer: 'Bureau Veritas', desc: 'Sistema de gestión de calidad de nuestros procesos, certificado en 2026.' },
+        { title: 'Bronze System Integrator', issuer: 'Rockwell Automation', desc: 'Integradores de sistemas reconocidos en el programa PartnerNetwork de Rockwell.' },
       ],
     },
     testimonios: {
@@ -405,6 +406,7 @@ export const ui = {
       items: [
         { title: 'Certified panel builders', issuer: 'Servimeters', desc: 'Design and manufacturing of electrical panels under certification.' },
         { title: 'ISO 9001', issuer: 'Bureau Veritas', desc: 'Quality management system certified in 2026 across our processes.' },
+        { title: 'Bronze System Integrator', issuer: 'Rockwell Automation', desc: "Recognized system integrators in Rockwell's PartnerNetwork program." },
       ],
     },
     testimonios: {


### PR DESCRIPTION
Agrega **Bronze System Integrator · Rockwell Automation** como tercer badge en la franja de Certificaciones (bilingüe ES/EN).

- El componente ahora soporta N badges por índice (ícono medal para el 3ro).
- Se mantiene 'RA Bronze' como stat de texto en el hero por consistencia visual (números + texto); el sello real va en la franja de certificaciones.
- Preparado para el logo oficial de Rockwell: dejar el archivo en `public/assets/certificaciones/` y su nombre en `seals` de `Certificaciones.astro`.

Nota: el logo de partner de Rockwell es marca controlada (PartnerNetwork, con guías de uso); conviene usar el archivo oficial, no una imagen genérica de internet.