### PR TITLE
fix(certificaciones): corrige el certificado de tableros (Intertek, no Servimeters)

### DIFF
--- a/src/components/nocturne/Certificaciones.astro
+++ b/src/components/nocturne/Certificaciones.astro
@@ -7,7 +7,7 @@ const t = ui[lang].certificaciones;
 
 // Sellos oficiales opcionales: colocá el archivo en public/assets/certificaciones/
 // y poné el nombre acá por índice (mismo orden que t.items). Vacío => badge con
-// ícono. Ej.: ['servimeters.png', 'bureau-veritas-iso9001.png', 'ra-bronze.png'].
+// ícono. Ej.: ['intertek.png', 'bureau-veritas-iso9001.png', 'ra-bronze.png'].
 const seals = ['', 'iso-9001-bureau-veritas.jpg', 'ra-bronze.png'];
 
 // Ícono por índice (mdi): shield-check, check-decagram, medal.

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -180,7 +180,7 @@ export const ui = {
       title: 'Respaldo que da confianza.',
       lead: 'Nuestra capacidad técnica y nuestros procesos están respaldados por certificaciones de terceros.',
       items: [
-        { title: 'Tableristas certificados', issuer: 'Servimeters', desc: 'Diseño y fabricación de tableros eléctricos bajo certificación.' },
+        { title: 'Tableros certificados', issuer: 'Intertek', desc: 'Certificación de producto RETIE de nuestros tableros eléctricos de baja tensión (IEC 61439). Certificado EL-CS-250379.' },
         { title: 'ISO 9001', issuer: 'Bureau Veritas', desc: 'Sistema de gestión de calidad de nuestros procesos, certificado en 2026.' },
         { title: 'Bronze System Integrator', issuer: 'Rockwell Automation', desc: 'Integradores de sistemas reconocidos en el programa PartnerNetwork de Rockwell.' },
       ],
@@ -404,7 +404,7 @@ export const ui = {
       title: 'Backing you can trust.',
       lead: 'Our technical capability and processes are backed by third-party certifications.',
       items: [
-        { title: 'Certified panel builders', issuer: 'Servimeters', desc: 'Design and manufacturing of electrical panels under certification.' },
+        { title: 'Certified panels', issuer: 'Intertek', desc: 'RETIE product certification of our low-voltage electrical panels (IEC 61439). Certificate EL-CS-250379.' },
         { title: 'ISO 9001', issuer: 'Bureau Veritas', desc: 'Quality management system certified in 2026 across our processes.' },
         { title: 'Bronze System Integrator', issuer: 'Rockwell Automation', desc: "Recognized system integrators in Rockwell's PartnerNetwork program." },
       ],


### PR DESCRIPTION
El primer sello decía 'Tableristas certificados — Servimeters', pero el certificado real (`EL-CS-250379`) es un **Certificado de Producto de Intertek Colombia** (esquema RETIE) que certifica los **tableros eléctricos de baja tensión** marca S&G bajo IEC 61439 (ensayos FAST TEST/CIDET, acreditación ONAC/IAF). Vigencia 2026–2030.

**Corrección:** emisor Servimeters → **Intertek**, título → **Tableros certificados** / **Certified panels**, descripción con el nº de certificado. Bilingüe ES/EN.

Nota: sigue como badge ícono+texto; si querés, sumamos el sello oficial de Intertek cuando esté disponible.