### PR TITLE
feat(seo): páginas por línea de servicio, schema local y Core Web Vitals

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-2555128146281676, DIRECT, f08c47fec0942fa0

--- a/src/components/PageHome.astro
+++ b/src/components/PageHome.astro
@@ -11,7 +11,8 @@ import Nosotros from './nocturne/Nosotros.astro';
 import Certificaciones from './nocturne/Certificaciones.astro';
 import Testimonios from './nocturne/Testimonios.astro';
 import Contacto from './nocturne/Contacto.astro';
-import { ui, getLang } from '../i18n/ui';
+import { ui, getLang, localePath, pageTitle } from '../i18n/ui';
+import { servicios } from '../data/servicios';
 
 const lang = getLang(Astro.currentLocale);
 const m = ui[lang].meta;
@@ -39,13 +40,51 @@ const knowsAbout = lang === 'en'
       'Desarrollo de software industrial',
     ];
 
+const SITE = 'https://www.sgsolucionesing.com';
+
+// Coordenadas de la sede, tomadas del mapa embebido en /contacto.
+const GEO = { lat: 11.0002399922035, lon: -74.7994586851977 };
+
+// Horario de atención publicado en /contacto.
+const horario = [
+  {
+    '@type': 'OpeningHoursSpecification',
+    dayOfWeek: ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday'],
+    opens: '08:00',
+    closes: '17:00',
+  },
+  {
+    '@type': 'OpeningHoursSpecification',
+    dayOfWeek: ['Saturday'],
+    opens: '08:00',
+    closes: '12:00',
+  },
+];
+
+// El catálogo sale de la misma fuente que las páginas de servicio, así que no
+// puede quedar desalineado con lo que el sitio realmente publica.
+const catalogo = {
+  '@type': 'OfferCatalog',
+  name: lang === 'en' ? 'Engineering services' : 'Servicios de ingeniería',
+  itemListElement: servicios.map((svc) => ({
+    '@type': 'Offer',
+    itemOffered: {
+      '@type': 'Service',
+      name: svc[lang].title,
+      description: svc[lang].metaDescription,
+      url: new URL(localePath(`/servicios/${svc.slug}`, lang), SITE).href,
+    },
+  })),
+};
+
 const jsonld = {
   '@context': 'https://schema.org',
   '@type': 'ProfessionalService',
+  '@id': `${SITE}/#organization`,
   name: 'S&G Soluciones de Ingeniería',
-  url: 'https://www.sgsolucionesing.com',
-  logo: 'https://www.sgsolucionesing.com/logo.png',
-  image: 'https://www.sgsolucionesing.com/assets/img/pruebas-1.jpg',
+  url: SITE,
+  logo: `${SITE}/logo.png`,
+  image: `${SITE}/assets/img/pruebas-1.jpg`,
   description: m.jsonldDescription,
   telephone: '+573243025107',
   email: 'comercial.proyectos@sgsolucionesing.com',
@@ -56,11 +95,18 @@ const jsonld = {
     addressRegion: 'Atlántico',
     addressCountry: 'CO',
   },
+  geo: { '@type': 'GeoCoordinates', latitude: GEO.lat, longitude: GEO.lon },
+  hasMap: `https://www.google.com/maps/search/?api=1&query=${GEO.lat},${GEO.lon}`,
+  openingHoursSpecification: horario,
   areaServed,
   knowsAbout,
+  availableLanguage: ['es', 'en'],
+  hasOfferCatalog: catalogo,
+  // `sameAs` queda fuera a propósito: no hay perfiles sociales confirmados.
+  // Declarar uno equivocado es peor que no declarar ninguno.
 };
 ---
-<BaseLayout title={m.homeTitle} description={m.homeDescription} hasAlternate={true}>
+<BaseLayout title={pageTitle(m.homeTitle)} description={m.homeDescription} hasAlternate={true}>
   <script type="application/ld+json" slot="head" set:html={JSON.stringify(jsonld)} />
 
   <Hero />

--- a/src/components/PageProyecto.astro
+++ b/src/components/PageProyecto.astro
@@ -3,7 +3,8 @@
 // Detalle de proyecto compartido por /proyectos/[slug] (ES) y /en/proyectos/[slug] (EN).
 // El cuerpo MDX se pasa por el slot "body". El idioma se resuelve por currentLocale.
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { ui, getLang, localePath, sectorLabel } from '../i18n/ui';
+import { ui, getLang, localePath, sectorLabel, pageTitle } from '../i18n/ui';
+import { imgSize } from '../lib/imageSize';
 
 interface Props {
   proyecto: any;
@@ -16,13 +17,13 @@ const t = ui[lang].proyectos;
 const site = 'https://www.sgsolucionesing.com';
 
 const sector = sectorLabel(data.sector, lang);
-const pageTitle = `${data.title} | S&G Soluciones de Ingeniería`;
+const docTitle = pageTitle(data.title);
 const pageDescription = data.resumen;
 const coverImageUrl = new URL(data.coverImage, site).href;
 const logoUrl = new URL('/logo.png', site).href;
 const canonicalUrl = new URL(Astro.url.pathname, site).href;
 ---
-<BaseLayout title={pageTitle} description={pageDescription} image={data.coverImage} type="article" hasAlternate={true}>
+<BaseLayout title={docTitle} description={pageDescription} image={data.coverImage} type="article" hasAlternate={true}>
   <script type="application/ld+json" slot="head" set:html={JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'Article',
@@ -51,7 +52,7 @@ const canonicalUrl = new URL(Astro.url.pathname, site).href;
   })} />
 
   <header class="phead">
-    <div class="bg"><img src={data.coverImage} alt="" aria-hidden="true" fetchpriority="high" /></div>
+    <div class="bg"><img src={data.coverImage} alt="" aria-hidden="true" fetchpriority="high" {...imgSize(data.coverImage)} /></div>
     <div class="wrap">
       <a class="crumb" href={localePath('/proyectos', lang)}><span class="back"></span> {t.crumb}</a>
       <div class="metaline rv in">{[sector, data.ubicacion, data.fecha].filter(Boolean).join(' · ')}</div>
@@ -99,7 +100,7 @@ const canonicalUrl = new URL(Astro.url.pathname, site).href;
         <div class="gal-grid">
           {data.gallery.map((image, index) => (
             <div class="g-item" data-index={index}>
-              <img src={image} alt={`${data.title} - ${t.imageWord} ${index + 1}`} loading="lazy" decoding="async" />
+              <img src={image} alt={`${data.title} - ${t.imageWord} ${index + 1}`} loading="lazy" decoding="async" {...imgSize(image)} />
             </div>
           ))}
         </div>

--- a/src/components/PageProyectos.astro
+++ b/src/components/PageProyectos.astro
@@ -3,7 +3,8 @@
 // Listado de proyectos compartido por /proyectos (ES) y /en/proyectos (EN).
 // Recibe `items` ya filtrados por idioma; el idioma se resuelve por currentLocale.
 import BaseLayout from '../layouts/BaseLayout.astro';
-import { ui, getLang, localePath, sectorLabel } from '../i18n/ui';
+import { ui, getLang, localePath, sectorLabel, pageTitle } from '../i18n/ui';
+import { imgSize } from '../lib/imageSize';
 
 interface Props {
   items: any[];
@@ -18,7 +19,7 @@ const canonical = new URL(Astro.url.pathname, site).href;
 // URL base (sin prefijo /en) de una entrada, para armar el href localizado.
 const baseSlug = (c: any) => (c.slug || c.id.split('/').pop().replace(/\.mdx?$/, '')).replace(/^en\//, '');
 ---
-<BaseLayout title={t.metaTitle} description={t.metaDesc} image="/assets/img/tablero-1.jpg" hasAlternate={true}>
+<BaseLayout title={pageTitle(t.metaTitle)} description={t.metaDesc} image="/assets/img/tablero-1.jpg" hasAlternate={true}>
   <script type="application/ld+json" slot="head" set:html={JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'CollectionPage',
@@ -36,7 +37,7 @@ const baseSlug = (c: any) => (c.slug || c.id.split('/').pop().replace(/\.mdx?$/,
   })} />
 
   <header class="phead">
-    <div class="bg"><img src="/assets/img/tablero-1.jpg" alt="" aria-hidden="true" fetchpriority="high" /></div>
+    <div class="bg"><img src="/assets/img/tablero-1.jpg" alt="" aria-hidden="true" fetchpriority="high" {...imgSize("/assets/img/tablero-1.jpg")} /></div>
     <div class="wrap">
       <span class="kick rv in">{t.kick}</span>
       <h1 class="rv in d1" set:html={t.h1Html}></h1>
@@ -56,7 +57,7 @@ const baseSlug = (c: any) => (c.slug || c.id.split('/').pop().replace(/\.mdx?$/,
         <article class="case rv">
           <figure class="fig">
             <span class="mk2"></span>
-            <img src={c.data.coverImage} alt={c.data.title} loading="lazy" decoding="async" />
+            <img src={c.data.coverImage} alt={c.data.title} loading="lazy" decoding="async" {...imgSize(c.data.coverImage)} />
             {c.data.kpis?.[0] && <span class="tagline">{c.data.kpis[0].value}</span>}
             <span class="mk"></span>
           </figure>

--- a/src/components/PageServicio.astro
+++ b/src/components/PageServicio.astro
@@ -1,0 +1,194 @@
+---
+// src/components/PageServicio.astro
+// Detalle de una línea de servicio, compartido por /servicios/<slug> (ES) y
+// /en/servicios/<slug> (EN). Recibe el servicio y los casos ya resueltos contra
+// la colección `proyectos` en el idioma que corresponde.
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { ui, getLang, localePath, sectorLabel, pageTitle } from '../i18n/ui';
+import { servicios, type Servicio } from '../data/servicios';
+import { imgSize } from '../lib/imageSize';
+
+interface Props {
+  servicio: Servicio;
+  /** Entradas de `proyectos` que ejemplifican este servicio, en el idioma actual. */
+  casos: any[];
+}
+const { servicio, casos } = Astro.props;
+
+const lang = getLang(Astro.currentLocale);
+const t = ui[lang].serviciosPage;
+const c = servicio[lang];
+const site = 'https://www.sgsolucionesing.com';
+const canonical = new URL(Astro.url.pathname, site).href;
+
+// Otras líneas de servicio, para enlazado interno entre páginas hermanas.
+const otras = servicios.filter((s) => s.slug !== servicio.slug);
+
+// URL base (sin prefijo /en) de una entrada de proyecto, para armar el href localizado.
+const baseSlug = (e: any) =>
+  (e.slug || e.id.split('/').pop().replace(/\.mdx?$/, '')).replace(/^en\//, '');
+
+const serviceLd = {
+  '@context': 'https://schema.org',
+  '@type': 'Service',
+  name: c.title,
+  serviceType: c.title,
+  description: c.metaDescription,
+  url: canonical,
+  image: new URL(servicio.image, site).href,
+  provider: {
+    '@type': 'ProfessionalService',
+    name: 'S&G Soluciones de Ingeniería',
+    url: site,
+    telephone: '+573243025107',
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: 'Carrera 44 #69-80',
+      addressLocality: 'Barranquilla',
+      addressRegion: 'Atlántico',
+      addressCountry: 'CO',
+    },
+  },
+  areaServed: [
+    { '@type': 'Country', name: 'Colombia' },
+    { '@type': 'City', name: 'Barranquilla' },
+  ],
+  availableLanguage: ['es', 'en'],
+  hasOfferCatalog: {
+    '@type': 'OfferCatalog',
+    name: c.title,
+    itemListElement: c.alcance.map((b) => ({
+      '@type': 'Offer',
+      itemOffered: { '@type': 'Service', name: b.title, description: b.desc },
+    })),
+  },
+};
+
+const faqLd = {
+  '@context': 'https://schema.org',
+  '@type': 'FAQPage',
+  mainEntity: c.faq.map((f) => ({
+    '@type': 'Question',
+    name: f.q,
+    acceptedAnswer: { '@type': 'Answer', text: f.a },
+  })),
+};
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: t.home, item: new URL(localePath('/', lang), site).href },
+    { '@type': 'ListItem', position: 2, name: t.crumb, item: new URL(localePath('/servicios', lang), site).href },
+    { '@type': 'ListItem', position: 3, name: c.title, item: canonical },
+  ],
+};
+---
+<BaseLayout
+  title={pageTitle(c.metaTitle)}
+  description={c.metaDescription}
+  image={servicio.image}
+  hasAlternate={true}
+>
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify(serviceLd)} />
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify(faqLd)} />
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify(breadcrumb)} />
+
+  <header class="phead">
+    <div class="bg">
+      <img src={servicio.image} alt="" aria-hidden="true" fetchpriority="high" {...imgSize(servicio.image)} />
+    </div>
+    <div class="wrap">
+      <a class="crumb" href={localePath('/servicios', lang)}><span class="back"></span> {t.crumb}</a>
+      <h1 class="rv in d1">{c.h1}</h1>
+      <p class="resumen rv in d2">{c.lead}</p>
+    </div>
+  </header>
+
+  <section class="sec">
+    <div class="wrap">
+      <h2 class="rv svc-h2">{t.scopeTitle}</h2>
+      <div class="svc-scope">
+        {c.alcance.map((b) => (
+          <article class="scope-item rv">
+            <h3>{b.title}</h3>
+            <p>{b.desc}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="sec alt">
+    <div class="wrap">
+      <h2 class="rv svc-h2">{t.deliverablesTitle}</h2>
+      <ul class="svc-deliver rv">
+        {c.entregables.map((e) => <li>{e}</li>)}
+      </ul>
+    </div>
+  </section>
+
+  {casos.length > 0 && (
+    <section class="sec">
+      <div class="wrap">
+        <h2 class="rv svc-h2">{t.casesTitle}</h2>
+        <p class="svc-lead rv">{t.casesLead}</p>
+        <div class="svc-cases">
+          {casos.map((e) => (
+            <a class="svc-case rv" href={localePath(`/proyectos/${baseSlug(e)}`, lang)}>
+              <div class="ph">
+                <img
+                  src={e.data.coverImage}
+                  alt={e.data.title}
+                  loading="lazy"
+                  decoding="async"
+                  {...imgSize(e.data.coverImage)}
+                />
+              </div>
+              <div class="tx">
+                <span class="sector">{sectorLabel(e.data.sector, lang)}</span>
+                <h3>{e.data.title}</h3>
+                <p>{e.data.resumen}</p>
+              </div>
+            </a>
+          ))}
+        </div>
+      </div>
+    </section>
+  )}
+
+  <section class="sec alt">
+    <div class="wrap">
+      <h2 class="rv svc-h2">{t.faqTitle}</h2>
+      <div class="svc-faq">
+        {c.faq.map((f) => (
+          <article class="faq-item rv">
+            <h3>{f.q}</h3>
+            <p>{f.a}</p>
+          </article>
+        ))}
+      </div>
+    </div>
+  </section>
+
+  <section class="sec">
+    <div class="wrap">
+      <h2 class="rv svc-h2">{t.relatedTitle}</h2>
+      <ul class="svc-related rv">
+        {otras.map((s) => (
+          <li>
+            <a href={localePath(`/servicios/${s.slug}`, lang)}>{s[lang].title}</a>
+          </li>
+        ))}
+      </ul>
+    </div>
+  </section>
+
+  <section class="svc-cta">
+    <div class="wrap">
+      <h2 class="rv">{t.ctaTitle}</h2>
+      <p class="rv d1">{t.ctaLead}</p>
+      <a class="cta rv d2" href={localePath('/#contacto', lang)}>{t.ctaButton}</a>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/components/PageServicios.astro
+++ b/src/components/PageServicios.astro
@@ -1,0 +1,90 @@
+---
+// src/components/PageServicios.astro
+// Hub de servicios, compartido por /servicios (ES) y /en/servicios (EN).
+// El idioma se resuelve por Astro.currentLocale, igual que en el resto del sitio.
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { ui, getLang, localePath, pageTitle } from '../i18n/ui';
+import { servicios } from '../data/servicios';
+import { imgSize } from '../lib/imageSize';
+
+const lang = getLang(Astro.currentLocale);
+const t = ui[lang].serviciosPage;
+const site = 'https://www.sgsolucionesing.com';
+const canonical = new URL(Astro.url.pathname, site).href;
+
+// ItemList explícito: le dice al buscador que esta página indexa las ocho
+// líneas y cuál es la URL canónica de cada una.
+const itemList = {
+  '@context': 'https://schema.org',
+  '@type': 'ItemList',
+  name: t.metaTitle,
+  description: t.metaDesc,
+  url: canonical,
+  numberOfItems: servicios.length,
+  itemListElement: servicios.map((svc, i) => ({
+    '@type': 'ListItem',
+    position: i + 1,
+    name: svc[lang].title,
+    url: new URL(localePath(`/servicios/${svc.slug}`, lang), site).href,
+  })),
+};
+
+const breadcrumb = {
+  '@context': 'https://schema.org',
+  '@type': 'BreadcrumbList',
+  itemListElement: [
+    { '@type': 'ListItem', position: 1, name: t.home, item: new URL(localePath('/', lang), site).href },
+    { '@type': 'ListItem', position: 2, name: t.crumb, item: canonical },
+  ],
+};
+---
+<BaseLayout
+  title={pageTitle(t.metaTitle)}
+  description={t.metaDesc}
+  image="/assets/img/tablero-1.jpg"
+  hasAlternate={true}
+>
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify(itemList)} />
+  <script type="application/ld+json" slot="head" set:html={JSON.stringify(breadcrumb)} />
+
+  <header class="phead">
+    <div class="bg">
+      <img src="/assets/img/tablero-1.jpg" alt="" aria-hidden="true" fetchpriority="high" {...imgSize("/assets/img/tablero-1.jpg")} />
+    </div>
+    <div class="wrap">
+      <span class="kick rv in">{t.kick}</span>
+      <h1 class="rv in d1" set:html={t.h1Html}></h1>
+      <p class="rv in d2">{t.lead}</p>
+    </div>
+  </header>
+
+  <section class="sec">
+    <div class="wrap">
+      <div class="svc-grid">
+        {servicios.map((svc, i) => {
+          const c = svc[lang];
+          const href = localePath(`/servicios/${svc.slug}`, lang);
+          return (
+            <article class="svc rv">
+              <div class="num">{String(i + 1).padStart(2, '0')}</div>
+              <h2><a href={href}>{c.title}</a></h2>
+              <p>{c.desc}</p>
+              <div class="tags">
+                {c.tags.map((tag) => <span class="tag">{tag}</span>)}
+              </div>
+              <a class="svc-link" href={href}>{t.viewService}</a>
+            </article>
+          );
+        })}
+      </div>
+    </div>
+  </section>
+
+  <section class="svc-cta">
+    <div class="wrap">
+      <h2 class="rv">{t.ctaTitle}</h2>
+      <p class="rv d1">{t.ctaLead}</p>
+      <a class="cta rv d2" href={localePath('/#contacto', lang)}>{t.ctaButton}</a>
+    </div>
+  </section>
+</BaseLayout>

--- a/src/components/nocturne/Casos.astro
+++ b/src/components/nocturne/Casos.astro
@@ -2,6 +2,7 @@
 // src/components/nocturne/Casos.astro
 import { getCollection } from 'astro:content';
 import { ui, getLang, localePath } from '../../i18n/ui';
+import { imgSize } from '../../lib/imageSize';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].casos;
 const isEn = lang === 'en';
@@ -24,7 +25,7 @@ const caseHref = (c) => localePath(`/proyectos/${(c.slug || '').replace(/^en\//,
       {casos.map((c) => (
         <article class="case rv">
           <a class="fig" href={caseHref(c)}>
-            <img src={c.data.coverImage} alt={c.data.title} loading="lazy" decoding="async" />
+            <img src={c.data.coverImage} alt={c.data.title} loading="lazy" decoding="async" {...imgSize(c.data.coverImage)} />
             <span class="meta">{[c.data.sector, c.data.ubicacion, c.data.fecha].filter(Boolean).join(' · ')}</span>
           </a>
           <div class="body">

--- a/src/components/nocturne/Certificaciones.astro
+++ b/src/components/nocturne/Certificaciones.astro
@@ -2,6 +2,7 @@
 // src/components/nocturne/Certificaciones.astro
 // Franja de certificaciones y credenciales (sellos de respaldo). Bilingüe ES/EN.
 import { ui, getLang } from '../../i18n/ui';
+import { imgSize } from '../../lib/imageSize';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].certificaciones;
 
@@ -32,6 +33,7 @@ const iconPaths = [
               alt={`${c.title} — ${c.issuer}`}
               loading="lazy"
               decoding="async"
+              {...imgSize(`/assets/certificaciones/${seals[i]}`)}
             />
           ) : (
             <div class="cert-seal">

--- a/src/components/nocturne/Clientes.astro
+++ b/src/components/nocturne/Clientes.astro
@@ -3,6 +3,7 @@
 // logo: nombre de archivo en public/assets/logos/ (logo oficial verificado).
 // Sin `logo` => se muestra como wordmark de texto (no se encontró un logo confiable).
 import { ui, getLang } from '../../i18n/ui';
+import { imgSize } from '../../lib/imageSize';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].clientes;
 const clientes = [
@@ -34,6 +35,7 @@ const clientes = [
             class="logo-img"
             loading="lazy"
             decoding="async"
+            {...imgSize(`/assets/logos/${c.logo}`)}
           />
         ) : (
           <span class="logo">{c.name}</span>

--- a/src/components/nocturne/Hero.astro
+++ b/src/components/nocturne/Hero.astro
@@ -1,12 +1,13 @@
 ---
 // src/components/nocturne/Hero.astro
 import { ui, getLang } from '../../i18n/ui';
+import { imgSize } from '../../lib/imageSize';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].hero;
 ---
 <header class="hero">
   <div class="bg">
-    <img src="/assets/img/pruebas-1.jpg" alt="" fetchpriority="high" />
+    <img src="/assets/img/pruebas-1.jpg" alt="" fetchpriority="high" {...imgSize("/assets/img/pruebas-1.jpg")} />
   </div>
   <div class="inner">
     <p class="kick rv in">{t.kick}</p>

--- a/src/components/nocturne/Nosotros.astro
+++ b/src/components/nocturne/Nosotros.astro
@@ -1,6 +1,7 @@
 ---
 // src/components/nocturne/Nosotros.astro
 import { ui, getLang } from '../../i18n/ui';
+import { imgSize } from '../../lib/imageSize';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].nosotros;
 ---
@@ -8,7 +9,7 @@ const t = ui[lang].nosotros;
   <div class="wrap about">
     <figure class="fig rv">
       <span class="mk2"></span>
-      <img src="/assets/img/about.jpg" alt={t.imgAlt} loading="lazy" decoding="async" />
+      <img src="/assets/img/about.jpg" alt={t.imgAlt} loading="lazy" decoding="async" {...imgSize("/assets/img/about.jpg")} />
       <span class="mk"></span>
     </figure>
     <div>

--- a/src/components/nocturne/Servicios.astro
+++ b/src/components/nocturne/Servicios.astro
@@ -1,8 +1,14 @@
 ---
 // src/components/nocturne/Servicios.astro
-import { ui, getLang } from '../../i18n/ui';
+// Sección "Servicios" del home. Las tarjetas se arman desde src/data/servicios.ts
+// —la misma fuente que alimenta /servicios y cada detalle— y enlazan a su página,
+// de modo que cada línea de servicio tenga una URL propia que pueda posicionar.
+import { ui, getLang, localePath } from '../../i18n/ui';
+import { servicios } from '../../data/servicios';
+
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].servicios;
+const tp = ui[lang].serviciosPage;
 ---
 <section class="sec" id="servicios">
   <div class="wrap">
@@ -14,16 +20,24 @@ const t = ui[lang].servicios;
       <p class="lead rv">{t.lead}</p>
     </div>
     <div class="svc-grid">
-      {t.items.map((svc, i) => (
-        <article class="svc rv">
-          <div class="num">{String(i + 1).padStart(2, '0')}</div>
-          <h3>{svc.title}</h3>
-          <p>{svc.desc}</p>
-          <div class="tags">
-            {svc.tags.map((tag) => <span class="tag">{tag}</span>)}
-          </div>
-        </article>
-      ))}
+      {servicios.map((svc, i) => {
+        const c = svc[lang];
+        const href = localePath(`/servicios/${svc.slug}`, lang);
+        return (
+          <article class="svc rv">
+            <div class="num">{String(i + 1).padStart(2, '0')}</div>
+            <h3><a href={href}>{c.title}</a></h3>
+            <p>{c.desc}</p>
+            <div class="tags">
+              {c.tags.map((tag) => <span class="tag">{tag}</span>)}
+            </div>
+            <a class="svc-link" href={href}>{tp.viewService}</a>
+          </article>
+        );
+      })}
+    </div>
+    <div class="svc-all rv">
+      <a class="btn-ghost" href={localePath('/servicios', lang)}>{tp.seeAll}</a>
     </div>
   </div>
 </section>

--- a/src/components/nocturne/Testimonios.astro
+++ b/src/components/nocturne/Testimonios.astro
@@ -1,12 +1,13 @@
 ---
 // src/components/nocturne/Testimonios.astro
 import { ui, getLang } from '../../i18n/ui';
+import { imgSize } from '../../lib/imageSize';
 const lang = getLang(Astro.currentLocale);
 const t = ui[lang].testimonios;
 ---
 <section class="sec quote">
   <div class="bg" aria-hidden="true">
-    <img src="/assets/img/portada-principal.jpg" alt="" loading="lazy" decoding="async" />
+    <img src="/assets/img/portada-principal.jpg" alt="" loading="lazy" decoding="async" {...imgSize("/assets/img/portada-principal.jpg")} />
   </div>
   <div class="wrap">
     <div class="mark">&quot;</div>

--- a/src/content/proyectos/en/gelco-subestacion-2-miobox.mdx
+++ b/src/content/proyectos/en/gelco-subestacion-2-miobox.mdx
@@ -1,5 +1,5 @@
 ---
-title: Comprehensive Renovation of Substation 2 with MIOBOX Energy Management
+title: Comprehensive Renovation of Substation 2 with MIOBOX
 sector: Alimentos
 fecha: "2024"
 cliente: GELCO

--- a/src/content/proyectos/en/litoplas-shelter-vfd.mdx
+++ b/src/content/proyectos/en/litoplas-shelter-vfd.mdx
@@ -4,7 +4,7 @@ sector: Industrial
 fecha: "2019"
 cliente: Litoplas
 coverImage: /assets/images/proyectos/litoplas-shelter-vfd/cover.jpg
-resumen: Climate-controlled shelter that preserves the optimal environment for the variable frequency drives of extruders 21, 9 and 5, eliminating overtemperature faults and machine stoppages.
+resumen: Climate-controlled shelter preserving the environment for the drives of extruders 21, 9 and 5, eliminating overtemperature faults and machine stoppages.
 kpis:
   - label: Extruders covered
     value: "3"

--- a/src/content/proyectos/gelco-subestacion-2-miobox.mdx
+++ b/src/content/proyectos/gelco-subestacion-2-miobox.mdx
@@ -1,5 +1,5 @@
 ---
-title: Renovación Integral de Subestación 2 con Gestión Energética MIOBOX
+title: Renovación Integral de Subestación 2 con MIOBOX
 sector: Alimentos
 fecha: "2024"
 cliente: GELCO

--- a/src/content/proyectos/litoplas-shelter-vfd.mdx
+++ b/src/content/proyectos/litoplas-shelter-vfd.mdx
@@ -4,7 +4,7 @@ sector: Industrial
 fecha: "2019"
 cliente: Litoplas
 coverImage: "/assets/images/proyectos/litoplas-shelter-vfd/cover.jpg"
-resumen: Shelter climatizado que preserva el ambiente óptimo de los variadores de velocidad de las extrusoras 21, 9 y 5, eliminando las fallas por sobretemperatura y las paradas de máquina.
+resumen: Shelter climatizado que preserva el ambiente de los variadores de las extrusoras 21, 9 y 5, y elimina las fallas por sobretemperatura y las paradas de máquina.
 kpis:
   - { label: "Extrusoras cubiertas", value: "3" }
   - { label: "Variadores protegidos", value: "VFD" }

--- a/src/data/servicios.ts
+++ b/src/data/servicios.ts
@@ -1,0 +1,994 @@
+// src/data/servicios.ts
+// Fuente única de verdad de las líneas de servicio.
+//
+// Alimenta cuatro consumidores, para que no puedan divergir entre sí:
+//   1. la sección "Servicios" del home (tarjetas resumidas),
+//   2. el hub /servicios (y /en/servicios),
+//   3. cada página de detalle /servicios/<slug>,
+//   4. el `hasOfferCatalog` del JSON-LD de la organización.
+//
+// `casos` referencia slugs de la colección `proyectos`; cada página de servicio
+// resuelve esos slugs contra la colección para enlazar trabajo real. Un servicio
+// puede quedarse sin casos publicados: en ese escenario la sección simplemente
+// no se renderiza, en lugar de mostrar trabajo que no le corresponde.
+
+export interface ServicioBloque {
+  title: string;
+  desc: string;
+}
+
+export interface ServicioFaq {
+  q: string;
+  a: string;
+}
+
+/** Contenido de un servicio en un idioma. */
+export interface ServicioLocale {
+  /** Nombre corto, usado en tarjetas, navegación y migas. */
+  title: string;
+  /** Resumen de una o dos frases para la tarjeta del home. */
+  desc: string;
+  /** Etiquetas técnicas de la tarjeta. */
+  tags: string[];
+  /** <title> del documento. */
+  metaTitle: string;
+  /** <meta name="description">, máximo 160 caracteres. */
+  metaDescription: string;
+  /** Encabezado principal de la página de detalle. */
+  h1: string;
+  /** Párrafo de entrada bajo el H1. */
+  lead: string;
+  /** Qué cubre el servicio, desglosado. */
+  alcance: ServicioBloque[];
+  /** Qué recibe el cliente al cerrar el trabajo. */
+  entregables: string[];
+  /** Preguntas frecuentes; alimentan también el JSON-LD FAQPage. */
+  faq: ServicioFaq[];
+}
+
+export interface Servicio {
+  /** Segmento de URL, compartido por ambos idiomas. */
+  slug: string;
+  /** Imagen de cabecera; ruta bajo /public. */
+  image: string;
+  /** Slugs de la colección `proyectos` que ejemplifican este servicio. */
+  casos: string[];
+  es: ServicioLocale;
+  en: ServicioLocale;
+}
+
+export const servicios: Servicio[] = [
+  {
+    slug: 'automatizacion-y-control-industrial',
+    image: '/assets/images/proyectos/litoplas-extrusora-27/cover.jpg',
+    casos: [
+      'litoplas-extrusora-27',
+      'litoplas-migracion-scada',
+      'litoplas-cortadora',
+      'gelco-filtros-arena',
+      'farmacapsulab-encapsuladora',
+      'ultracem-e300-scada',
+      'sonepar-tablero-despacho',
+    ],
+    es: {
+      title: 'Automatización y Control Industrial',
+      desc: 'Arquitectura de control, programación de PLC, HMI/SCADA, control batch, MES/MOM y networking industrial. Migración de controladores, puesta en marcha (FAT/SAT) y tableros CCM y consolas de operación.',
+      tags: ['Allen Bradley', 'Siemens', 'SCADA', 'MIOBOX'],
+      metaTitle: 'Automatización y Control Industrial en Barranquilla',
+      metaDescription:
+        'Programación de PLC, HMI/SCADA, migración de controladores y puesta en marcha FAT/SAT sobre Allen Bradley y Siemens. Integradores en Barranquilla, Colombia.',
+      h1: 'Automatización y control industrial',
+      lead: 'Diseñamos e integramos la capa de control de la planta: desde la arquitectura y la programación del PLC hasta el SCADA que el operador usa cada turno. Trabajamos sobre plataformas Allen Bradley y Siemens, y conectamos el proceso a MIOBOX cuando la operación necesita ver sus indicadores en tiempo real.',
+      alcance: [
+        {
+          title: 'Arquitectura de control',
+          desc: 'Definimos la topología del sistema —controladores, E/S remotas, redes y niveles de red— antes de escribir una línea de código, para que la solución acompañe el crecimiento de la planta en lugar de limitarlo.',
+        },
+        {
+          title: 'Programación de PLC y HMI/SCADA',
+          desc: 'Programamos controladores Allen Bradley (ControlLogix, CompactLogix) y Siemens (S7-1500, TIA Portal), con interfaces de operación en FactoryTalk View, WinCC e InTouch.',
+        },
+        {
+          title: 'Migración de controladores obsoletos',
+          desc: 'Reemplazamos plataformas fuera de soporte conservando la lógica de proceso probada, con estrategias de corte que reducen la ventana de parada.',
+        },
+        {
+          title: 'Control batch y MES/MOM',
+          desc: 'Estructuramos recetas, fases y trazabilidad de lote para procesos por cargas, e integramos la capa de control con los sistemas de gestión de manufactura.',
+        },
+        {
+          title: 'Networking industrial',
+          desc: 'Segmentación y puesta a punto de redes EtherNet/IP, Profinet y Modbus, con switches administrables de grado industrial.',
+        },
+        {
+          title: 'Puesta en marcha FAT/SAT',
+          desc: 'Pruebas en fábrica y en sitio con protocolos documentados, acompañamiento en el arranque y transferencia de conocimiento al equipo de mantenimiento.',
+        },
+      ],
+      entregables: [
+        'Programa del controlador comentado y con respaldo entregado al cliente',
+        'Aplicación HMI/SCADA con sus pantallas de operación y alarmas',
+        'Planos eléctricos y de red actualizados según lo construido',
+        'Protocolos FAT y SAT firmados',
+        'Capacitación al personal de operación y mantenimiento',
+      ],
+      faq: [
+        {
+          q: '¿Pueden migrar un control obsoleto sin parar la producción por completo?',
+          a: 'En la mayoría de los casos sí. Preparamos y probamos el tablero y el programa nuevos por fuera de la línea, y dejamos la conmutación para una ventana de parada acordada —normalmente un mantenimiento programado o un fin de semana—. La lógica de proceso que ya funciona se conserva; lo que cambia es la plataforma que la ejecuta.',
+        },
+        {
+          q: '¿Trabajan con Allen Bradley y con Siemens?',
+          a: 'Con ambas. Somos Bronze System Integrator de Rockwell Automation y también desarrollamos sobre Siemens S7-1500 y TIA Portal. La plataforma se elige por lo que ya existe en la planta y por el soporte disponible, no por preferencia del integrador.',
+        },
+        {
+          q: '¿El código del PLC queda en manos del cliente?',
+          a: 'Sí. Entregamos el programa comentado y su respaldo, junto con los planos actualizados. La planta debe poder mantener su propio sistema sin depender de quien lo instaló.',
+        },
+      ],
+    },
+    en: {
+      title: 'Industrial Automation & Control',
+      desc: 'Control architecture, PLC programming, HMI/SCADA, batch control, MES/MOM and industrial networking. Controller migration, commissioning (FAT/SAT), MCC panels and operator consoles.',
+      tags: ['Allen Bradley', 'Siemens', 'SCADA', 'MIOBOX'],
+      metaTitle: 'Industrial Automation & Control in Colombia',
+      metaDescription:
+        'PLC programming, HMI/SCADA, controller migration and FAT/SAT commissioning on Allen Bradley and Siemens. System integrators based in Barranquilla, Colombia.',
+      h1: 'Industrial automation and control',
+      lead: "We design and integrate the plant's control layer: from system architecture and PLC programming to the SCADA your operators use every shift. We work on Allen Bradley and Siemens platforms, and connect the process to MIOBOX when the operation needs its indicators in real time.",
+      alcance: [
+        {
+          title: 'Control architecture',
+          desc: 'We define system topology —controllers, remote I/O, networks and network levels— before writing a single line of code, so the solution supports the plant as it grows instead of constraining it.',
+        },
+        {
+          title: 'PLC and HMI/SCADA programming',
+          desc: 'We program Allen Bradley (ControlLogix, CompactLogix) and Siemens (S7-1500, TIA Portal) controllers, with operator interfaces in FactoryTalk View, WinCC and InTouch.',
+        },
+        {
+          title: 'Legacy controller migration',
+          desc: 'We replace out-of-support platforms while preserving proven process logic, using cutover strategies that shorten the shutdown window.',
+        },
+        {
+          title: 'Batch control and MES/MOM',
+          desc: 'We structure recipes, phases and batch traceability for batch processes, and integrate the control layer with manufacturing management systems.',
+        },
+        {
+          title: 'Industrial networking',
+          desc: 'Segmentation and tuning of EtherNet/IP, Profinet and Modbus networks, with industrial-grade managed switches.',
+        },
+        {
+          title: 'FAT/SAT commissioning',
+          desc: 'Factory and site acceptance testing against documented protocols, start-up support and knowledge transfer to your maintenance team.',
+        },
+      ],
+      entregables: [
+        'Commented controller program, with a backup handed over to the client',
+        'HMI/SCADA application with its operating screens and alarms',
+        'Electrical and network drawings updated as-built',
+        'Signed FAT and SAT protocols',
+        'Training for operations and maintenance personnel',
+      ],
+      faq: [
+        {
+          q: 'Can you migrate a legacy control system without a full production stop?',
+          a: 'In most cases, yes. We build and test the new panel and program off-line, and reserve the cutover for an agreed shutdown window —typically scheduled maintenance or a weekend. The process logic that already works is preserved; what changes is the platform running it.',
+        },
+        {
+          q: 'Do you work with both Allen Bradley and Siemens?',
+          a: 'Both. We are a Rockwell Automation Bronze System Integrator and we also develop on Siemens S7-1500 and TIA Portal. The platform is chosen based on what the plant already runs and the support available, not on the integrator’s preference.',
+        },
+        {
+          q: 'Does the client keep the PLC code?',
+          a: 'Yes. We hand over the commented program and its backup, along with updated drawings. A plant must be able to maintain its own system without depending on whoever installed it.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'instrumentacion-industrial',
+    image: '/assets/images/proyectos/gelco-control-secado/cover.jpg',
+    casos: ['gelco-control-secado', 'sonepar-tablero-despacho', 'cabot-gestor-energia'],
+    es: {
+      title: 'Instrumentación Industrial',
+      desc: 'Selección e implementación de instrumentos, diseño de lazos de control y ajuste de transmisores de temperatura, presión, caudal y humedad, con aseguramiento metrológico.',
+      tags: ['Lazos de control', 'Transmisores', 'Metrología'],
+      metaTitle: 'Instrumentación Industrial y Lazos de Control',
+      metaDescription:
+        'Selección, montaje y ajuste de transmisores de temperatura, presión, caudal y humedad. Diseño de lazos de control y aseguramiento metrológico en planta.',
+      h1: 'Instrumentación industrial',
+      lead: 'Un sistema de control no puede ser mejor que la medición que lo alimenta. Seleccionamos, instalamos y ajustamos la instrumentación de campo, y diseñamos los lazos de control que convierten esa medición en una acción estable sobre el proceso.',
+      alcance: [
+        {
+          title: 'Selección de instrumentos',
+          desc: 'Elegimos el principio de medición, el rango y los materiales según las condiciones reales del proceso —temperatura, presión, agresividad del fluido y clasificación del área— y no según el catálogo más a mano.',
+        },
+        {
+          title: 'Diseño de lazos de control',
+          desc: 'Definimos la estrategia de control, la sintonía de los lazos y las protecciones, para que el proceso responda sin oscilar ni saturar el elemento final.',
+        },
+        {
+          title: 'Transmisores de proceso',
+          desc: 'Montaje y ajuste de transmisores de temperatura, presión, caudal, nivel y humedad, con su cableado, condicionamiento de señal y verificación punto a punto.',
+        },
+        {
+          title: 'Aseguramiento metrológico',
+          desc: 'Verificación y trazabilidad de las mediciones críticas, para que los datos que sostienen las decisiones de proceso sean defendibles.',
+        },
+        {
+          title: 'Integración con el control',
+          desc: 'Llevamos la señal de campo hasta el PLC y el SCADA, con escalamiento, filtrado y alarmas coherentes con la operación.',
+        },
+      ],
+      entregables: [
+        'Hojas de datos de los instrumentos seleccionados',
+        'Diagramas de lazo y planos de instrumentación actualizados',
+        'Registro de verificación y ajuste de cada punto de medición',
+        'Parámetros de sintonía documentados',
+        'Capacitación al personal de mantenimiento sobre la instrumentación instalada',
+      ],
+      faq: [
+        {
+          q: '¿Cómo saben qué instrumento corresponde a mi proceso?',
+          a: 'Partimos de las condiciones reales de operación: fluido, rango, temperatura, presión, exigencia de exactitud y clasificación del área. Ese conjunto descarta la mayoría de las opciones antes de mirar marca o precio. Como somos distribuidores multimarca, la recomendación no está atada a un solo fabricante.',
+        },
+        {
+          q: '¿Pueden intervenir solo la instrumentación, sin tocar el control?',
+          a: 'Sí. Podemos limitarnos al campo —selección, montaje, cableado y ajuste— e integrarnos a la lógica de control que ya tenga la planta. Cuando el lazo requiere cambios en el programa, lo indicamos antes de empezar.',
+        },
+        {
+          q: '¿Qué incluye el aseguramiento metrológico?',
+          a: 'La verificación de que cada medición crítica es trazable y está dentro de tolerancia, con su registro correspondiente. Es lo que permite sostener una decisión de proceso —o una auditoría— con evidencia y no con una lectura suelta.',
+        },
+      ],
+    },
+    en: {
+      title: 'Industrial Instrumentation',
+      desc: 'Instrument selection and implementation, control loop design and tuning of temperature, pressure, flow and humidity transmitters, with metrological assurance.',
+      tags: ['Control loops', 'Transmitters', 'Metrology'],
+      metaTitle: 'Industrial Instrumentation & Control Loops',
+      metaDescription:
+        'Selection, installation and tuning of temperature, pressure, flow and humidity transmitters. Control loop design and metrological assurance on the plant floor.',
+      h1: 'Industrial instrumentation',
+      lead: 'A control system can never be better than the measurement feeding it. We select, install and tune field instrumentation, and design the control loops that turn that measurement into stable action on the process.',
+      alcance: [
+        {
+          title: 'Instrument selection',
+          desc: 'We choose the measuring principle, range and materials based on actual process conditions —temperature, pressure, fluid aggressiveness and area classification— rather than on whichever catalogue is closest to hand.',
+        },
+        {
+          title: 'Control loop design',
+          desc: 'We define the control strategy, loop tuning and protections, so the process responds without oscillating or saturating the final element.',
+        },
+        {
+          title: 'Process transmitters',
+          desc: 'Installation and tuning of temperature, pressure, flow, level and humidity transmitters, including wiring, signal conditioning and point-to-point verification.',
+        },
+        {
+          title: 'Metrological assurance',
+          desc: 'Verification and traceability of critical measurements, so the data behind process decisions can be defended.',
+        },
+        {
+          title: 'Integration with the control layer',
+          desc: 'We bring the field signal into the PLC and SCADA, with scaling, filtering and alarms consistent with how the plant actually operates.',
+        },
+      ],
+      entregables: [
+        'Datasheets for every selected instrument',
+        'Loop diagrams and updated instrumentation drawings',
+        'Verification and adjustment record for each measuring point',
+        'Documented tuning parameters',
+        'Training for maintenance personnel on the installed instrumentation',
+      ],
+      faq: [
+        {
+          q: 'How do you determine the right instrument for my process?',
+          a: 'We start from actual operating conditions: fluid, range, temperature, pressure, accuracy requirements and area classification. That set rules out most options before brand or price enters the conversation. Because we are a multi-brand distributor, our recommendation is not tied to a single manufacturer.',
+        },
+        {
+          q: 'Can you work on instrumentation only, without touching the control system?',
+          a: 'Yes. We can stay in the field —selection, installation, wiring and tuning— and integrate with the control logic the plant already runs. When a loop does require program changes, we flag it before starting.',
+        },
+        {
+          q: 'What does metrological assurance cover?',
+          a: 'Verification that each critical measurement is traceable and within tolerance, with its corresponding record. That is what lets you defend a process decision —or an audit— with evidence rather than an isolated reading.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'eficiencia-energetica',
+    image: '/assets/images/proyectos/cabot-gestor-energia/cover.jpg',
+    casos: [
+      'cabot-gestor-energia',
+      'gelco-subestacion-1-miobox',
+      'gelco-subestacion-2-miobox',
+      'gelco-medida-media-tension',
+    ],
+    es: {
+      title: 'Eficiencia Energética',
+      desc: 'Análisis de calidad de energía, monitoreo y telemedida, y proyectos de ahorro energético con incorporación de energías renovables.',
+      tags: ['Calidad de energía', 'Telemedida', 'Renovables'],
+      metaTitle: 'Eficiencia Energética y Calidad de Energía Industrial',
+      metaDescription:
+        'Análisis de calidad de energía, telemedida y monitoreo en tiempo real con MIOBOX. Proyectos de ahorro energético y energías renovables para la industria.',
+      h1: 'Eficiencia energética',
+      lead: 'La energía suele ser el segundo costo de una planta industrial y el peor medido. Instrumentamos la subestación y los circuitos críticos, llevamos esa medición a MIOBOX y convertimos el consumo en un indicador que la gerencia puede seguir y sobre el que puede decidir.',
+      alcance: [
+        {
+          title: 'Análisis de calidad de energía',
+          desc: 'Medición y diagnóstico de armónicos, factor de potencia, desbalance y perturbaciones, para identificar qué está degradando los equipos y encareciendo la factura.',
+        },
+        {
+          title: 'Monitoreo y telemedida',
+          desc: 'Instalación de medidores en subestación y circuitos críticos, con transmisión continua hacia MIOBOX para ver el consumo por área, línea o turno.',
+        },
+        {
+          title: 'Corrección del factor de potencia',
+          desc: 'Dimensionamiento e instalación de bancos de condensadores, de 1 a 1520 kvar, con la protección y maniobra que corresponde a cada instalación.',
+        },
+        {
+          title: 'Proyectos de ahorro energético',
+          desc: 'Identificación de oportunidades a partir de la medición real, con la estimación de ahorro asociada a cada intervención antes de ejecutarla.',
+        },
+        {
+          title: 'Incorporación de energías renovables',
+          desc: 'Evaluación e integración de generación renovable en la instalación existente, considerando su efecto sobre la operación y sobre la infraestructura eléctrica actual.',
+        },
+      ],
+      entregables: [
+        'Informe de calidad de energía con las mediciones de base',
+        'Tablero de indicadores de consumo en MIOBOX',
+        'Memoria de cálculo del banco de condensadores, cuando aplica',
+        'Plan de intervenciones priorizado por ahorro estimado',
+        'Planos eléctricos actualizados según lo construido',
+      ],
+      faq: [
+        {
+          q: '¿Por dónde se empieza un proyecto de eficiencia energética?',
+          a: 'Por medir. Sin una línea base real no hay forma de saber si una intervención ahorró algo ni cuánto. El primer paso es instrumentar la subestación y los circuitos que más pesan, dejar correr la medición y recién entonces priorizar dónde intervenir.',
+        },
+        {
+          q: '¿Qué es MIOBOX y por qué aparece en estos proyectos?',
+          a: 'Es nuestra plataforma propia de microservicios IIoT. Recoge la medición de campo y la presenta como indicadores de gestión, para que el consumo se pueda seguir por área, línea o turno en lugar de aparecer una vez al mes en la factura.',
+        },
+        {
+          q: '¿Corregir el factor de potencia siempre conviene?',
+          a: 'Conviene cuando la penalización existe y la instalación lo permite. Antes de proponer un banco medimos: si hay armónicos importantes, un banco mal dimensionado puede entrar en resonancia y empeorar las cosas. Por eso el dimensionamiento sale de la medición, no de un estimado.',
+        },
+      ],
+    },
+    en: {
+      title: 'Energy Efficiency',
+      desc: 'Power quality analysis, monitoring and telemetering, and energy-saving projects including renewable energy integration.',
+      tags: ['Power quality', 'Telemetering', 'Renewables'],
+      metaTitle: 'Industrial Energy Efficiency & Power Quality',
+      metaDescription:
+        'Power quality analysis, telemetering and real-time monitoring with MIOBOX. Energy-saving and renewable energy projects for industry in Colombia.',
+      h1: 'Energy efficiency',
+      lead: 'Energy is usually the second largest cost in an industrial plant, and the worst measured. We instrument the substation and the critical feeders, bring that measurement into MIOBOX, and turn consumption into an indicator leadership can track and act on.',
+      alcance: [
+        {
+          title: 'Power quality analysis',
+          desc: 'Measurement and diagnosis of harmonics, power factor, imbalance and disturbances, to identify what is degrading equipment and inflating the bill.',
+        },
+        {
+          title: 'Monitoring and telemetering',
+          desc: 'Meter installation at the substation and on critical feeders, streaming continuously into MIOBOX so consumption can be seen by area, line or shift.',
+        },
+        {
+          title: 'Power factor correction',
+          desc: 'Sizing and installation of capacitor banks, from 1 to 1520 kvar, with the protection and switchgear each installation calls for.',
+        },
+        {
+          title: 'Energy-saving projects',
+          desc: 'Opportunities identified from actual measurement, each with its estimated saving established before the work is carried out.',
+        },
+        {
+          title: 'Renewable energy integration',
+          desc: 'Assessment and integration of renewable generation into the existing installation, accounting for its effect on operations and on current electrical infrastructure.',
+        },
+      ],
+      entregables: [
+        'Power quality report with baseline measurements',
+        'Consumption dashboard in MIOBOX',
+        'Capacitor bank sizing calculations, where applicable',
+        'Intervention plan prioritised by estimated saving',
+        'Electrical drawings updated as-built',
+      ],
+      faq: [
+        {
+          q: 'Where does an energy efficiency project start?',
+          a: 'With measurement. Without a real baseline there is no way to know whether an intervention saved anything, or how much. The first step is to instrument the substation and the heaviest feeders, let the measurement run, and only then prioritise where to act.',
+        },
+        {
+          q: 'What is MIOBOX, and why does it appear in these projects?',
+          a: 'It is our own IIoT microservices platform. It collects field measurement and presents it as management indicators, so consumption can be tracked by area, line or shift instead of showing up once a month on the utility bill.',
+        },
+        {
+          q: 'Is power factor correction always worth it?',
+          a: 'It is worth it when the penalty exists and the installation allows for it. Before proposing a bank we measure: if significant harmonics are present, an incorrectly sized bank can resonate and make things worse. That is why sizing comes from measurement, not from an estimate.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'montaje-electrico',
+    image: '/assets/images/proyectos/gelco-medida-media-tension/cover.jpg',
+    casos: [
+      'gelco-medida-media-tension',
+      'gelco-factibilidad-carga',
+      'gelco-transferencia-automatica',
+      'polyrec-seccionador-sf6',
+      'gelco-subestacion-1-miobox',
+    ],
+    es: {
+      title: 'Montaje Eléctrico',
+      desc: 'Diseño de instalaciones eléctricas, estudios de factibilidad y montaje industrial y comercial, con mantenimiento y cumplimiento normativo RETIE.',
+      tags: ['RETIE', 'Montaje industrial', 'Mantenimiento'],
+      metaTitle: 'Montaje Eléctrico Industrial y RETIE en Barranquilla',
+      metaDescription:
+        'Diseño y montaje de instalaciones eléctricas industriales y comerciales, subestaciones y media tensión, con cumplimiento RETIE. Barranquilla y toda Colombia.',
+      h1: 'Montaje eléctrico',
+      lead: 'Diseñamos y ejecutamos instalaciones eléctricas industriales y comerciales, desde el estudio de factibilidad hasta la entrega con cumplimiento RETIE. Intervenimos baja y media tensión: subestaciones, sistemas de medida, transferencias automáticas y protecciones.',
+      alcance: [
+        {
+          title: 'Estudios de factibilidad',
+          desc: 'Evaluación de la capacidad instalada frente a la carga proyectada, para saber qué admite la instalación actual antes de comprometer una ampliación.',
+        },
+        {
+          title: 'Diseño de instalaciones eléctricas',
+          desc: 'Cálculo y diseño de acometidas, tableros, canalizaciones y puestas a tierra, con la memoria de cálculo que exige la normativa.',
+        },
+        {
+          title: 'Subestaciones y media tensión',
+          desc: 'Montaje y renovación de subestaciones, sistemas de medida en media tensión, seccionadores y equipos de protección y maniobra.',
+        },
+        {
+          title: 'Transferencias automáticas',
+          desc: 'Instalación de sistemas de transferencia con planta de respaldo, para que los procesos críticos no dependan de la continuidad de la red.',
+        },
+        {
+          title: 'Cumplimiento RETIE',
+          desc: 'Ejecutamos conforme al Reglamento Técnico de Instalaciones Eléctricas y acompañamos el proceso de certificación con la documentación correspondiente.',
+        },
+        {
+          title: 'Mantenimiento eléctrico',
+          desc: 'Mantenimiento preventivo y correctivo de la instalación, con inspección termográfica y revisión de protecciones.',
+        },
+      ],
+      entregables: [
+        'Memorias de cálculo y planos eléctricos según lo construido',
+        'Documentación para el proceso de certificación RETIE',
+        'Protocolos de prueba de protecciones y puesta a tierra',
+        'Registro fotográfico del montaje',
+        'Recomendaciones de mantenimiento para la instalación entregada',
+      ],
+      faq: [
+        {
+          q: '¿Qué exige RETIE en un montaje eléctrico industrial?',
+          a: 'RETIE es el reglamento técnico obligatorio en Colombia para instalaciones eléctricas. Exige que el diseño tenga memorias de cálculo, que los productos usados estén certificados, que la ejecución la haga personal competente y que la instalación se someta a inspección por un organismo acreditado. Nosotros ejecutamos bajo ese marco y entregamos la documentación que el inspector va a pedir.',
+        },
+        {
+          q: '¿Hacen el estudio de factibilidad antes de la ampliación?',
+          a: 'Sí, y recomendamos hacerlo. Sumar carga sin verificar qué admite la subestación, la acometida y las protecciones es la vía más rápida a una falla o a un rechazo en la inspección. El estudio dice qué se puede conectar hoy y qué requiere obra previa.',
+        },
+        {
+          q: '¿Intervienen media tensión?',
+          a: 'Sí. Hemos ejecutado sistemas de medida en media tensión, seccionadores SF6, reconexión automática y renovación de subestaciones, siempre con la coordinación de protecciones que corresponde.',
+        },
+      ],
+    },
+    en: {
+      title: 'Electrical Installation',
+      desc: 'Electrical installation design, feasibility studies and industrial and commercial installation work, with maintenance and RETIE regulatory compliance.',
+      tags: ['RETIE', 'Industrial installation', 'Maintenance'],
+      metaTitle: 'Industrial Electrical Installation & RETIE Compliance',
+      metaDescription:
+        'Design and installation of industrial and commercial electrical systems, substations and medium voltage, with RETIE compliance. Barranquilla, Colombia.',
+      h1: 'Electrical installation',
+      lead: 'We design and execute industrial and commercial electrical installations, from the feasibility study through to handover with RETIE compliance. We work in both low and medium voltage: substations, metering systems, automatic transfer schemes and protection.',
+      alcance: [
+        {
+          title: 'Feasibility studies',
+          desc: 'Assessment of installed capacity against projected load, so you know what the current installation can take before committing to an expansion.',
+        },
+        {
+          title: 'Electrical installation design',
+          desc: 'Calculation and design of service entrances, panels, raceways and earthing systems, with the calculation records the regulation requires.',
+        },
+        {
+          title: 'Substations and medium voltage',
+          desc: 'Installation and renovation of substations, medium-voltage metering systems, disconnectors and protection and switching equipment.',
+        },
+        {
+          title: 'Automatic transfer schemes',
+          desc: 'Installation of transfer systems with standby generation, so critical processes do not depend on grid continuity.',
+        },
+        {
+          title: 'RETIE compliance',
+          desc: 'We execute in line with Colombia’s technical regulation for electrical installations and support the certification process with the corresponding documentation.',
+        },
+        {
+          title: 'Electrical maintenance',
+          desc: 'Preventive and corrective maintenance of the installation, including thermographic inspection and protection review.',
+        },
+      ],
+      entregables: [
+        'Calculation records and as-built electrical drawings',
+        'Documentation for the RETIE certification process',
+        'Test protocols for protection systems and earthing',
+        'Photographic record of the installation work',
+        'Maintenance recommendations for the delivered installation',
+      ],
+      faq: [
+        {
+          q: 'What does RETIE require on an industrial electrical installation?',
+          a: 'RETIE is Colombia’s mandatory technical regulation for electrical installations. It requires calculation records behind the design, certified products, execution by competent personnel, and inspection by an accredited body. We execute within that framework and hand over the documentation the inspector will ask for.',
+        },
+        {
+          q: 'Do you run a feasibility study before an expansion?',
+          a: 'Yes, and we recommend it. Adding load without verifying what the substation, service entrance and protection can take is the fastest route to a failure or to a rejected inspection. The study establishes what can be connected today and what requires prior work.',
+        },
+        {
+          q: 'Do you work on medium voltage?',
+          a: 'Yes. We have delivered medium-voltage metering systems, SF6 disconnectors, automatic reclosing and substation renovations, always with the corresponding protection coordination.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'mantenimiento-mecanico',
+    image: '/assets/img/pruebas-1.jpg',
+    casos: ['litoplas-shelter-vfd'],
+    es: {
+      title: 'Mantenimiento Mecánico',
+      desc: 'Mantenimiento preventivo y correctivo, montaje y diagnóstico de equipos, soldadura y fabricación de piezas para mantener la planta en operación.',
+      tags: ['Preventivo', 'Correctivo', 'Soldadura'],
+      metaTitle: 'Mantenimiento Mecánico Industrial',
+      metaDescription:
+        'Mantenimiento preventivo y correctivo, montaje y diagnóstico de equipos, soldadura y fabricación de piezas para plantas industriales en Colombia.',
+      h1: 'Mantenimiento mecánico',
+      lead: 'Un proyecto de automatización sirve de poco si el equipo que controla se detiene por una falla mecánica. Cubrimos el mantenimiento preventivo y correctivo, el montaje y el diagnóstico de equipos, y fabricamos las piezas que hacen falta cuando el repuesto no llega a tiempo.',
+      alcance: [
+        {
+          title: 'Mantenimiento preventivo',
+          desc: 'Planes de intervención por equipo y frecuencia, para reemplazar la reparación de urgencia por una parada programada.',
+        },
+        {
+          title: 'Mantenimiento correctivo',
+          desc: 'Atención de fallas con diagnóstico de causa, no solo reposición de la pieza rota, para que el mismo problema no vuelva en el próximo turno.',
+        },
+        {
+          title: 'Montaje y alineación de equipos',
+          desc: 'Instalación, nivelación y alineación de equipos rotativos y de transmisión, con la verificación posterior al montaje.',
+        },
+        {
+          title: 'Soldadura y fabricación de piezas',
+          desc: 'Fabricación de componentes y estructuras a medida cuando el repuesto original está descontinuado o su tiempo de entrega compromete la producción.',
+        },
+        {
+          title: 'Diagnóstico de equipos',
+          desc: 'Evaluación del estado del equipo para decidir con criterio entre reparar, reconstruir o reemplazar.',
+        },
+      ],
+      entregables: [
+        'Informe de diagnóstico con la causa identificada',
+        'Registro de las intervenciones realizadas',
+        'Plan de mantenimiento preventivo por equipo',
+        'Planos de las piezas fabricadas a medida',
+        'Recomendaciones de repuestos críticos a mantener en stock',
+      ],
+      faq: [
+        {
+          q: '¿Atienden fallas puntuales o solo contratos de mantenimiento?',
+          a: 'Ambos. Atendemos la falla puntual con diagnóstico de causa, y también armamos planes preventivos por equipo cuando la planta quiere dejar de operar en modo reactivo.',
+        },
+        {
+          q: '¿Fabrican piezas que ya no consigo?',
+          a: 'Sí. Cuando el repuesto original está descontinuado o su tiempo de entrega no acompaña a la producción, fabricamos el componente a medida a partir de la pieza existente o del plano.',
+        },
+        {
+          q: '¿Este servicio se combina con la parte eléctrica y de control?',
+          a: 'Suele convenir. Muchas fallas que se leen como eléctricas son mecánicas, y al revés. Poder intervenir las tres capas evita el ida y vuelta entre proveedores mientras el equipo sigue detenido.',
+        },
+      ],
+    },
+    en: {
+      title: 'Mechanical Maintenance',
+      desc: 'Preventive and corrective maintenance, equipment installation and diagnostics, welding and custom part manufacturing to keep the plant running.',
+      tags: ['Preventive', 'Corrective', 'Welding'],
+      metaTitle: 'Industrial Mechanical Maintenance',
+      metaDescription:
+        'Preventive and corrective maintenance, equipment installation and diagnostics, welding and custom part manufacturing for industrial plants in Colombia.',
+      h1: 'Mechanical maintenance',
+      lead: 'An automation project counts for little if the equipment it controls stops on a mechanical failure. We cover preventive and corrective maintenance, equipment installation and diagnostics, and we manufacture the parts you need when the spare will not arrive in time.',
+      alcance: [
+        {
+          title: 'Preventive maintenance',
+          desc: 'Intervention plans by equipment and frequency, replacing emergency repair with scheduled downtime.',
+        },
+        {
+          title: 'Corrective maintenance',
+          desc: 'Failure response with root cause diagnosis, not just replacement of the broken part, so the same problem does not return next shift.',
+        },
+        {
+          title: 'Equipment installation and alignment',
+          desc: 'Installation, levelling and alignment of rotating and transmission equipment, with post-installation verification.',
+        },
+        {
+          title: 'Welding and part manufacturing',
+          desc: 'Custom components and structures manufactured when the original spare is discontinued or its lead time puts production at risk.',
+        },
+        {
+          title: 'Equipment diagnostics',
+          desc: 'Assessment of equipment condition to decide, on evidence, between repair, rebuild or replacement.',
+        },
+      ],
+      entregables: [
+        'Diagnostic report with the identified root cause',
+        'Record of the interventions carried out',
+        'Preventive maintenance plan by equipment',
+        'Drawings for any custom-manufactured parts',
+        'Recommendations on critical spares to keep in stock',
+      ],
+      faq: [
+        {
+          q: 'Do you handle one-off failures, or only maintenance contracts?',
+          a: 'Both. We respond to one-off failures with root cause diagnosis, and we also build preventive plans by equipment when a plant wants to stop operating reactively.',
+        },
+        {
+          q: 'Can you manufacture parts I can no longer source?',
+          a: 'Yes. When the original spare is discontinued or its lead time does not match production needs, we manufacture the component to measure from the existing part or from the drawing.',
+        },
+        {
+          q: 'Does this combine with the electrical and control work?',
+          a: 'It usually pays to. Many failures that read as electrical are mechanical, and the other way round. Being able to work across all three layers avoids bouncing between suppliers while the equipment stays down.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'tableros-electricos',
+    image: '/assets/img/tablero-1.jpg',
+    casos: [
+      'bb-tableros-baja-tension',
+      'gelco-subestacion-2-miobox',
+      'sonepar-tablero-despacho',
+      'litoplas-shelter-vfd',
+    ],
+    es: {
+      title: 'Diseño de Tableros Eléctricos',
+      desc: 'Tableros de distribución y transferencia automática, bancos de condensadores (1 a 1520 kvar), integración de PLC/IO y arranque de variadores de ½ a 900 HP.',
+      tags: ['Bancos de condensadores', 'Variadores ½–900 HP', 'PLC/IO'],
+      metaTitle: 'Diseño y Fabricación de Tableros Eléctricos',
+      metaDescription:
+        'Tableros de distribución, transferencia automática, bancos de condensadores de 1 a 1520 kvar y arranque de variadores de ½ a 900 HP. Fabricación bajo RETIE.',
+      h1: 'Diseño de tableros eléctricos',
+      lead: 'Diseñamos y fabricamos tableros de distribución, control, transferencia automática y corrección de factor de potencia. Cada tablero sale con su memoria de cálculo, sus planos y sus pruebas, porque un tablero mal dimensionado no falla el día que se instala: falla el día de más carga.',
+      alcance: [
+        {
+          title: 'Tableros de distribución y CCM',
+          desc: 'Tableros de distribución y centros de control de motores, con la coordinación de protecciones y la selectividad que exige la instalación.',
+        },
+        {
+          title: 'Transferencia automática',
+          desc: 'Tableros de transferencia entre red y planta de respaldo, con la lógica de conmutación y los enclavamientos de seguridad correspondientes.',
+        },
+        {
+          title: 'Bancos de condensadores',
+          desc: 'Corrección de factor de potencia de 1 a 1520 kvar, dimensionada a partir de la medición real y no de un estimado de placa.',
+        },
+        {
+          title: 'Arranque de motores y variadores',
+          desc: 'Arranque directo, suave y por variador de velocidad, de ½ a 900 HP, con la disipación y ventilación que el equipo necesita.',
+        },
+        {
+          title: 'Integración de PLC y E/S',
+          desc: 'Montaje del controlador, las E/S y la red dentro del mismo tablero, con el cableado identificado y accesible para mantenimiento.',
+        },
+        {
+          title: 'Consolas de operación',
+          desc: 'Consolas y pupitres de operación con su HMI, dispuestos según cómo trabaja realmente el operador en planta.',
+        },
+      ],
+      entregables: [
+        'Memoria de cálculo y selección de protecciones',
+        'Planos unifilares, de fuerza y de control',
+        'Listado de bornes y de cableado identificado',
+        'Protocolo de pruebas en fábrica (FAT) firmado',
+        'Manual del tablero y recomendaciones de mantenimiento',
+      ],
+      faq: [
+        {
+          q: '¿Fabrican el tablero o solo lo diseñan?',
+          a: 'Las dos cosas. Hacemos el diseño con su memoria de cálculo y la fabricación, y entregamos el tablero probado en fábrica antes de que salga hacia el sitio.',
+        },
+        {
+          q: '¿Qué rango de variadores manejan?',
+          a: 'De ½ a 900 HP. El dimensionamiento no termina en el variador: hay que resolver la disipación de calor dentro del tablero, y en algunos casos la solución correcta es un shelter climatizado en lugar de un gabinete convencional.',
+        },
+        {
+          q: '¿Los tableros cumplen RETIE?',
+          a: 'Sí. Fabricamos bajo el reglamento, con producto certificado y la documentación que requiere el proceso de inspección.',
+        },
+      ],
+    },
+    en: {
+      title: 'Electrical Panel Design',
+      desc: 'Distribution and automatic transfer panels, capacitor banks (1 to 1520 kvar), PLC/IO integration and motor drive starting from ½ to 900 HP.',
+      tags: ['Capacitor banks', 'Drives ½–900 HP', 'PLC/IO'],
+      metaTitle: 'Electrical Panel Design & Manufacturing',
+      metaDescription:
+        'Distribution panels, automatic transfer, capacitor banks from 1 to 1520 kvar and drive starting from ½ to 900 HP. Manufactured under RETIE regulation.',
+      h1: 'Electrical panel design',
+      lead: 'We design and manufacture distribution, control, automatic transfer and power factor correction panels. Every panel ships with its calculation records, drawings and test results, because an undersized panel does not fail the day it is installed: it fails on the heaviest load day.',
+      alcance: [
+        {
+          title: 'Distribution panels and MCCs',
+          desc: 'Distribution boards and motor control centres, with the protection coordination and selectivity the installation requires.',
+        },
+        {
+          title: 'Automatic transfer',
+          desc: 'Transfer panels between grid and standby generation, with the corresponding switching logic and safety interlocks.',
+        },
+        {
+          title: 'Capacitor banks',
+          desc: 'Power factor correction from 1 to 1520 kvar, sized from actual measurement rather than a nameplate estimate.',
+        },
+        {
+          title: 'Motor starting and drives',
+          desc: 'Direct, soft and variable frequency starting, from ½ to 900 HP, with the heat dissipation and ventilation the equipment needs.',
+        },
+        {
+          title: 'PLC and I/O integration',
+          desc: 'Controller, I/O and network mounted inside the same panel, with wiring labelled and accessible for maintenance.',
+        },
+        {
+          title: 'Operator consoles',
+          desc: 'Operator consoles and desks with their HMI, laid out around how the operator actually works on the plant floor.',
+        },
+      ],
+      entregables: [
+        'Calculation records and protection selection',
+        'Single-line, power and control drawings',
+        'Terminal schedule and labelled wiring list',
+        'Signed factory acceptance test (FAT) protocol',
+        'Panel manual and maintenance recommendations',
+      ],
+      faq: [
+        {
+          q: 'Do you manufacture the panel, or only design it?',
+          a: 'Both. We produce the design with its calculation records and the manufacturing, and hand over the panel factory-tested before it ships to site.',
+        },
+        {
+          q: 'What drive range do you handle?',
+          a: 'From ½ to 900 HP. Sizing does not stop at the drive: heat dissipation inside the panel has to be resolved, and in some cases the correct answer is a climate-controlled shelter rather than a conventional enclosure.',
+        },
+        {
+          q: 'Do the panels comply with RETIE?',
+          a: 'Yes. We manufacture under the regulation, with certified product and the documentation the inspection process requires.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'suministro-de-componentes',
+    image: '/assets/images/proyectos/bb-tableros-baja-tension/cover.jpg',
+    casos: ['bb-tableros-baja-tension', 'polyrec-seccionador-sf6', 'ultracem-e300-scada'],
+    es: {
+      title: 'Suministro y Asesoría de Componentes',
+      desc: 'Como distribuidores multimarca, suministramos partes y componentes eléctricos, electrónicos, de automatización y especializados. Sumamos valor asesorando su selección técnica —sensores, medidores, instrumentos y más— para que cada componente calce con la solución.',
+      tags: ['Distribuidor multimarca', 'Sensores y medidores', 'Asesoría técnica'],
+      metaTitle: 'Suministro de Componentes Eléctricos y de Automatización',
+      metaDescription:
+        'Distribuidor multimarca de componentes eléctricos, electrónicos y de automatización: sensores, medidores, instrumentos y repuestos, con asesoría técnica.',
+      h1: 'Suministro y asesoría de componentes',
+      lead: 'Suministramos partes y componentes eléctricos, electrónicos, de automatización y especializados. Como somos distribuidores multimarca y además integramos, la recomendación no está atada a un fabricante: proponemos el componente que resuelve el problema, no el que toca vender.',
+      alcance: [
+        {
+          title: 'Distribución multimarca',
+          desc: 'Acceso a componentes de distintos fabricantes, con la comparación técnica que permite decidir entre alternativas equivalentes.',
+        },
+        {
+          title: 'Asesoría técnica de selección',
+          desc: 'Verificamos que el componente sea compatible con la instalación existente —tensión, señal, protocolo, condiciones ambientales— antes de la compra y no después.',
+        },
+        {
+          title: 'Sensores, medidores e instrumentos',
+          desc: 'Instrumentación de proceso y medición eléctrica, seleccionada según el rango y la exactitud que el punto de medición realmente exige.',
+        },
+        {
+          title: 'Componentes de automatización',
+          desc: 'Controladores, E/S, variadores, relés inteligentes, equipos de red industrial y accesorios de tablero.',
+        },
+        {
+          title: 'Repuestos y obsolescencia',
+          desc: 'Búsqueda de repuestos para equipos en operación y propuesta de reemplazo equivalente cuando la referencia original quedó descontinuada.',
+        },
+      ],
+      entregables: [
+        'Cotización con la justificación técnica de cada referencia',
+        'Hojas de datos de los componentes propuestos',
+        'Verificación de compatibilidad con la instalación existente',
+        'Alternativas equivalentes cuando el plazo de entrega lo exige',
+        'Acompañamiento en la puesta en servicio del componente suministrado',
+      ],
+      faq: [
+        {
+          q: '¿Venden solo el componente o también lo instalan?',
+          a: 'Las dos opciones. Podemos limitarnos al suministro, o hacernos cargo del montaje y la puesta en servicio. La ventaja de que integremos es que la asesoría de selección viene de quien después tiene que hacer funcionar el equipo.',
+        },
+        {
+          q: 'Mi equipo usa una referencia descontinuada. ¿Tienen salida?',
+          a: 'Normalmente sí. Buscamos el repuesto en el mercado y, cuando ya no existe, proponemos un reemplazo equivalente verificando compatibilidad de tensión, señal, protocolo y montaje. Ese análisis es justamente donde se cometen los errores caros.',
+        },
+        {
+          q: '¿Por qué comprar acá y no directo al fabricante?',
+          a: 'Por la asesoría. Un fabricante recomienda su propio catálogo; nosotros comparamos entre marcas y verificamos que el componente calce con lo que la planta ya tiene instalado. Si la mejor opción es comprar directo, también lo decimos.',
+        },
+      ],
+    },
+    en: {
+      title: 'Component Supply & Advisory',
+      desc: 'As a multi-brand distributor, we supply electrical, electronic, automation and specialised parts and components. We add value by advising on technical selection —sensors, meters, instruments and more— so each component fits the solution.',
+      tags: ['Multi-brand distributor', 'Sensors and meters', 'Technical advisory'],
+      metaTitle: 'Electrical & Automation Component Supply',
+      metaDescription:
+        'Multi-brand distributor of electrical, electronic and automation components: sensors, meters, instruments and spares, with technical selection advisory.',
+      h1: 'Component supply and advisory',
+      lead: 'We supply electrical, electronic, automation and specialised parts and components. Because we are a multi-brand distributor and we also integrate, our recommendation is not tied to a manufacturer: we propose the component that solves the problem, not the one we happen to sell.',
+      alcance: [
+        {
+          title: 'Multi-brand distribution',
+          desc: 'Access to components from different manufacturers, with the technical comparison needed to decide between equivalent alternatives.',
+        },
+        {
+          title: 'Technical selection advisory',
+          desc: 'We verify the component is compatible with the existing installation —voltage, signal, protocol, environmental conditions— before purchase rather than after.',
+        },
+        {
+          title: 'Sensors, meters and instruments',
+          desc: 'Process instrumentation and electrical metering, selected for the range and accuracy the measuring point genuinely requires.',
+        },
+        {
+          title: 'Automation components',
+          desc: 'Controllers, I/O, drives, intelligent relays, industrial networking equipment and panel accessories.',
+        },
+        {
+          title: 'Spares and obsolescence',
+          desc: 'Sourcing of spares for equipment in service, and equivalent replacement proposals when the original reference has been discontinued.',
+        },
+      ],
+      entregables: [
+        'Quotation with technical justification for each reference',
+        'Datasheets for the proposed components',
+        'Compatibility verification against the existing installation',
+        'Equivalent alternatives when lead time demands it',
+        'Support during commissioning of the supplied component',
+      ],
+      faq: [
+        {
+          q: 'Do you only sell the component, or install it too?',
+          a: 'Either. We can limit ourselves to supply, or take on installation and commissioning. The advantage of us being integrators is that the selection advice comes from whoever then has to make the equipment work.',
+        },
+        {
+          q: 'My equipment uses a discontinued reference. Can you help?',
+          a: 'Usually yes. We source the spare on the market and, when it no longer exists, we propose an equivalent replacement after verifying voltage, signal, protocol and mounting compatibility. That analysis is exactly where the expensive mistakes get made.',
+        },
+        {
+          q: 'Why buy here instead of directly from the manufacturer?',
+          a: 'For the advisory. A manufacturer recommends its own catalogue; we compare across brands and verify the component fits what the plant already runs. If buying direct is genuinely the better option, we say so.',
+        },
+      ],
+    },
+  },
+  {
+    slug: 'vigilancia-electronica',
+    image: '/assets/img/portada-principal.jpg',
+    casos: [],
+    es: {
+      title: 'Vigilancia Electrónica',
+      desc: 'Suministro, instalación y montaje de sistemas de vigilancia y seguridad electrónica —CCTV, control de acceso y monitoreo— integrados a la infraestructura de la planta o la instalación.',
+      tags: ['CCTV', 'Control de acceso', 'Monitoreo'],
+      metaTitle: 'Vigilancia Electrónica, CCTV y Control de Acceso',
+      metaDescription:
+        'Suministro, instalación y montaje de CCTV, control de acceso y sistemas de monitoreo, integrados a la infraestructura de red de la planta o instalación.',
+      h1: 'Vigilancia electrónica',
+      lead: 'Suministramos, instalamos y montamos sistemas de vigilancia y seguridad electrónica. Al venir del mundo industrial, los integramos a la infraestructura de red que la planta ya tiene, en vez de montar una red paralela que después nadie mantiene.',
+      alcance: [
+        {
+          title: 'CCTV',
+          desc: 'Selección y montaje de cámaras según lo que hay que ver realmente —distancia, iluminación y condiciones ambientales— con su grabación y retención.',
+        },
+        {
+          title: 'Control de acceso',
+          desc: 'Sistemas de control de acceso a áreas restringidas, con la trazabilidad de entradas y salidas correspondiente.',
+        },
+        {
+          title: 'Monitoreo',
+          desc: 'Centralización de la vigilancia en un punto de monitoreo, con las alarmas y notificaciones que la operación necesita.',
+        },
+        {
+          title: 'Integración a la red existente',
+          desc: 'Montaje sobre la infraestructura de red de planta, con la segmentación adecuada para que el tráfico de video no interfiera con el de control.',
+        },
+      ],
+      entregables: [
+        'Plano de ubicación de cámaras y equipos con sus zonas de cobertura',
+        'Configuración de grabación, retención y accesos entregada al cliente',
+        'Documentación de la segmentación de red utilizada',
+        'Capacitación al personal responsable del monitoreo',
+        'Recomendaciones de mantenimiento del sistema',
+      ],
+      faq: [
+        {
+          q: '¿Puedo usar la red que ya tiene la planta?',
+          a: 'En general sí, y suele ser lo indicado. Lo importante es segmentar: el video consume ancho de banda y no debe compartir dominio con el tráfico de control. Esa separación la resolvemos en el diseño, no después.',
+        },
+        {
+          q: '¿Cuántas cámaras necesito?',
+          a: 'Depende de qué hay que ver, no del tamaño del predio. Partimos de las zonas y los eventos que se quieren cubrir, y de ahí sale la cantidad, el tipo de cámara y su ubicación. Más cámaras mal ubicadas no equivalen a más seguridad.',
+        },
+        {
+          q: '¿El sistema queda administrado por el cliente?',
+          a: 'Sí. Entregamos la configuración, los accesos y la capacitación al personal responsable, para que la planta administre su propio sistema.',
+        },
+      ],
+    },
+    en: {
+      title: 'Electronic Surveillance',
+      desc: 'Supply, installation and commissioning of surveillance and electronic security systems —CCTV, access control and monitoring— integrated into the plant or facility infrastructure.',
+      tags: ['CCTV', 'Access control', 'Monitoring'],
+      metaTitle: 'Electronic Surveillance, CCTV & Access Control',
+      metaDescription:
+        'Supply, installation and commissioning of CCTV, access control and monitoring systems, integrated into the existing plant or facility network infrastructure.',
+      h1: 'Electronic surveillance',
+      lead: 'We supply, install and commission surveillance and electronic security systems. Coming from the industrial world, we integrate them into the network infrastructure the plant already runs, instead of building a parallel network nobody ends up maintaining.',
+      alcance: [
+        {
+          title: 'CCTV',
+          desc: 'Camera selection and installation based on what actually needs to be seen —distance, lighting and environmental conditions— with its recording and retention.',
+        },
+        {
+          title: 'Access control',
+          desc: 'Access control systems for restricted areas, with the corresponding traceability of entries and exits.',
+        },
+        {
+          title: 'Monitoring',
+          desc: 'Surveillance centralised at a monitoring point, with the alarms and notifications the operation requires.',
+        },
+        {
+          title: 'Integration with the existing network',
+          desc: 'Deployment over the plant network infrastructure, with proper segmentation so video traffic does not interfere with control traffic.',
+        },
+      ],
+      entregables: [
+        'Layout of cameras and equipment with their coverage zones',
+        'Recording, retention and access configuration handed over to the client',
+        'Documentation of the network segmentation used',
+        'Training for the personnel responsible for monitoring',
+        'System maintenance recommendations',
+      ],
+      faq: [
+        {
+          q: 'Can I use the network the plant already has?',
+          a: 'Generally yes, and it is usually the right call. What matters is segmentation: video consumes bandwidth and should not share a domain with control traffic. We resolve that separation at design time, not afterwards.',
+        },
+        {
+          q: 'How many cameras do I need?',
+          a: 'It depends on what needs to be seen, not on the size of the site. We start from the zones and events you want covered, and the count, camera type and placement follow from that. More badly placed cameras do not add up to more security.',
+        },
+        {
+          q: 'Does the client administer the system?',
+          a: 'Yes. We hand over the configuration, the credentials and training for the responsible personnel, so the plant administers its own system.',
+        },
+      ],
+    },
+  },
+];
+
+/** Devuelve un servicio por su slug, o `undefined` si no existe. */
+export function getServicio(slug: string): Servicio | undefined {
+  return servicios.find((s) => s.slug === slug);
+}

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -25,6 +25,29 @@ export function sectorLabel(sector: string, lang: Lang): string {
   return map[sector] ?? sector;
 }
 
+export const BRAND = 'S&G Soluciones de Ingeniería';
+const BRAND_SHORT = 'S&G Ingeniería';
+
+// Google recorta el <title> alrededor de los 580 px, unos 60 caracteres. El
+// sufijo de marca completo se come 31 de esos, así que en la mayoría de las
+// páginas el nombre real quedaba cortado con puntos suspensivos.
+const TITLE_BUDGET = 60;
+
+/**
+ * Compone el <title> agregando la marca sólo mientras entre en el presupuesto:
+ * primero el nombre completo, luego la forma corta, y si el título por sí solo
+ * ya lo llena, se devuelve tal cual. Perder el sufijo no pierde la marca —
+ * Google la infiere de og:site_name y del JSON-LD de la organización—, pero
+ * perder el final del título sí pierde las palabras que posicionan.
+ */
+export function pageTitle(base: string): string {
+  const full = `${base} | ${BRAND}`;
+  if (full.length <= TITLE_BUDGET) return full;
+  const short = `${base} | ${BRAND_SHORT}`;
+  if (short.length <= TITLE_BUDGET) return short;
+  return base;
+}
+
 export const ui = {
   es: {
     nav: {
@@ -40,11 +63,24 @@ export const ui = {
     },
     footer: {
       copyright: '© 2026 · Barranquilla, Colombia · Automatización · Energía · Software',
+      servicesTitle: 'Servicios',
+      companyTitle: 'Empresa',
+      contactTitle: 'Contacto',
+      linkCases: 'Casos de éxito',
+      linkAbout: 'Nosotros',
+      linkContact: 'Contacto',
+      addressLabel: 'Dirección',
+      hoursLabel: 'Horario',
+      hours: 'Lun a vie 8:00–17:00 · Sáb 8:00–12:00',
+      blurb:
+        'Ingeniería en automatización industrial, instrumentación, eficiencia energética y software a la medida. Con base en Barranquilla, atendemos Colombia y Latinoamérica.',
     },
     meta: {
-      homeTitle: 'S&G Soluciones de Ingeniería | Automatización industrial, IoT y software',
+      // El nombre de marca va al final: los términos que la gente busca —lo que
+      // hacemos— tienen que caer antes del recorte del SERP.
+      homeTitle: 'Automatización Industrial, IoT y Energía',
       homeDescription:
-        'Automatización industrial, Industria 4.0/IoT, eficiencia energética, suministro de componentes y desarrollo de software para la industria. Con base en la costa Caribe (Barranquilla), atendemos Colombia y Latinoamérica.',
+        'Automatización industrial, Industria 4.0/IoT, eficiencia energética y software a la medida para la industria. Con base en Barranquilla, atendemos toda Colombia.',
       jsonldDescription:
         'Empresa de ingeniería especializada en automatización industrial, Industria 4.0/IoT, gestión y calidad de energía, suministro de componentes (distribuidor multimarca), vigilancia electrónica y desarrollo de software a la medida. Con base en Barranquilla, costa Caribe, atendemos a la industria de Colombia y Latinoamérica.',
       defaultDescription:
@@ -75,7 +111,7 @@ export const ui = {
       viewAll: 'Ver todos los casos',
     },
     proyectos: {
-      metaTitle: 'Casos de Éxito | S&G Soluciones de Ingeniería',
+      metaTitle: 'Casos de Éxito',
       metaDesc: 'Casos reales de automatización industrial, IoT e Industria 4.0: monitoreo predictivo, bancos de condensadores, tableros inteligentes y más resultados medibles.',
       kick: 'Casos de éxito',
       h1Html: 'Proyectos que se miden <em>en indicadores.</em>',
@@ -117,52 +153,33 @@ export const ui = {
       'Farmacéutico': 'Farmacéutico',
       'Otros': 'Otros',
     },
+    // Textos del hub /servicios y de cada página de detalle /servicios/<slug>.
+    // El contenido de cada servicio vive en src/data/servicios.ts.
+    serviciosPage: {
+      metaTitle: 'Servicios de Ingeniería Industrial',
+      metaDesc:
+        'Automatización y control, instrumentación, eficiencia energética, montaje eléctrico, tableros, mantenimiento, suministro de componentes y vigilancia electrónica.',
+      kick: 'Qué hacemos',
+      h1Html: 'Ocho líneas, <em>una sola cadena.</em>',
+      lead: 'Desde el componente y el tablero eléctrico hasta el indicador de gestión que ve la gerencia. Cada línea de servicio resuelve una parte del problema, y todas se integran entre sí porque las ejecuta el mismo equipo.',
+      crumb: 'Servicios',
+      home: 'Inicio',
+      viewService: 'Ver servicio',
+      seeAll: 'Ver todos los servicios',
+      scopeTitle: 'Qué incluye',
+      deliverablesTitle: 'Qué recibes',
+      faqTitle: 'Preguntas frecuentes',
+      casesTitle: 'Casos de éxito de esta línea',
+      casesLead: 'Trabajo entregado en planta dentro de este servicio.',
+      relatedTitle: 'Otras líneas de servicio',
+      ctaTitle: '¿Tienes un proyecto de este tipo?',
+      ctaLead: 'Cuéntanos qué necesitas resolver y te respondemos con una ruta clara para tu planta.',
+      ctaButton: 'Cotiza tu proyecto',
+    },
     servicios: {
       kick: 'Qué hacemos',
       h2Html: 'Del sensor <em>al indicador de gestión.</em>',
       lead: 'Automatización, instrumentación, eficiencia energética, suministro de componentes y vigilancia electrónica: cubrimos toda la cadena, desde el componente y el tablero eléctrico hasta el indicador de gestión que ve la gerencia.',
-      items: [
-        {
-          title: 'Automatización y Control Industrial',
-          desc: 'Arquitectura de control, programación de PLC, HMI/SCADA, control batch, MES/MOM y networking industrial. Migración de controladores, puesta en marcha (FAT/SAT) y tableros CCM y consolas de operación.',
-          tags: ['Allen Bradley', 'Siemens', 'SCADA', 'MIOBOX'],
-        },
-        {
-          title: 'Instrumentación Industrial',
-          desc: 'Selección e implementación de instrumentos, diseño de lazos de control y ajuste de transmisores de temperatura, presión, caudal y humedad, con aseguramiento metrológico.',
-          tags: ['Lazos de control', 'Transmisores', 'Metrología'],
-        },
-        {
-          title: 'Eficiencia Energética',
-          desc: 'Análisis de calidad de energía, monitoreo y telemedida, y proyectos de ahorro energético con incorporación de energías renovables.',
-          tags: ['Calidad de energía', 'Telemedida', 'Renovables'],
-        },
-        {
-          title: 'Montaje Eléctrico',
-          desc: 'Diseño de instalaciones eléctricas, estudios de factibilidad y montaje industrial y comercial, con mantenimiento y cumplimiento normativo RETIE.',
-          tags: ['RETIE', 'Montaje industrial', 'Mantenimiento'],
-        },
-        {
-          title: 'Mantenimiento Mecánico',
-          desc: 'Mantenimiento preventivo y correctivo, montaje y diagnóstico de equipos, soldadura y fabricación de piezas para mantener la planta en operación.',
-          tags: ['Preventivo', 'Correctivo', 'Soldadura'],
-        },
-        {
-          title: 'Diseño de Tableros Eléctricos',
-          desc: 'Tableros de distribución y transferencia automática, bancos de condensadores (1 a 1520 kvar), integración de PLC/IO y arranque de variadores de ½ a 900 HP.',
-          tags: ['Bancos de condensadores', 'Variadores ½–900 HP', 'PLC/IO'],
-        },
-        {
-          title: 'Suministro y Asesoría de Componentes',
-          desc: 'Como distribuidores multimarca, suministramos partes y componentes eléctricos, electrónicos, de automatización y especializados. Sumamos valor asesorando su selección técnica —sensores, medidores, instrumentos y más— para que cada componente calce con la solución.',
-          tags: ['Distribuidor multimarca', 'Sensores y medidores', 'Asesoría técnica'],
-        },
-        {
-          title: 'Vigilancia Electrónica',
-          desc: 'Suministro, instalación y montaje de sistemas de vigilancia y seguridad electrónica —CCTV, control de acceso y monitoreo— integrados a la infraestructura de la planta o la instalación.',
-          tags: ['CCTV', 'Control de acceso', 'Monitoreo'],
-        },
-      ],
     },
     nosotros: {
       kick: 'Quiénes somos',
@@ -264,11 +281,24 @@ export const ui = {
     },
     footer: {
       copyright: '© 2026 · Barranquilla, Colombia · Automation · Energy · Software',
+      servicesTitle: 'Services',
+      companyTitle: 'Company',
+      contactTitle: 'Contact',
+      linkCases: 'Case studies',
+      linkAbout: 'About',
+      linkContact: 'Contact',
+      addressLabel: 'Address',
+      hoursLabel: 'Hours',
+      hours: 'Mon–Fri 8:00–17:00 · Sat 8:00–12:00',
+      blurb:
+        'Engineering in industrial automation, instrumentation, energy efficiency and custom software. Based in Barranquilla, serving Colombia and Latin America.',
     },
     meta: {
-      homeTitle: 'S&G Soluciones de Ingeniería | Industrial automation, IoT & software',
+      // Brand name goes last: the terms people actually search for have to land
+      // before the SERP truncation.
+      homeTitle: 'Industrial Automation, IoT & Energy',
       homeDescription:
-        "Industrial automation, Industry 4.0/IoT, energy efficiency, component supply and custom software for industry. Based on Colombia's Caribbean coast (Barranquilla), we serve Colombia and Latin America.",
+        'Industrial automation, Industry 4.0/IoT, energy efficiency and custom software for industry. Based in Barranquilla, we serve Colombia and Latin America.',
       jsonldDescription:
         'Engineering company specialized in industrial automation, Industry 4.0/IoT, energy management and power quality, component supply (multi-brand distributor), electronic surveillance and custom software development. Based in Barranquilla, on the Caribbean coast, we serve industry across Colombia and Latin America.',
       defaultDescription:
@@ -299,7 +329,7 @@ export const ui = {
       viewAll: 'View all case studies',
     },
     proyectos: {
-      metaTitle: 'Case Studies | S&G Soluciones de Ingeniería',
+      metaTitle: 'Case Studies',
       metaDesc: 'Real cases of industrial automation, IoT and Industry 4.0: predictive monitoring, capacitor banks, smart panels and more measurable results.',
       kick: 'Case studies',
       h1Html: 'Projects measured <em>in indicators.</em>',
@@ -341,52 +371,33 @@ export const ui = {
       'Farmacéutico': 'Pharmaceutical',
       'Otros': 'Other',
     },
+    // Copy for the /en/servicios hub and each /en/servicios/<slug> detail page.
+    // Each service's own content lives in src/data/servicios.ts.
+    serviciosPage: {
+      metaTitle: 'Industrial Engineering Services',
+      metaDesc:
+        'Automation and control, instrumentation, energy efficiency, electrical installation, panels, maintenance, component supply and electronic surveillance.',
+      kick: 'What we do',
+      h1Html: 'Eight service lines, <em>one single chain.</em>',
+      lead: 'From the component and the electrical panel to the management KPI leadership sees. Each service line solves one part of the problem, and they all integrate because the same team delivers them.',
+      crumb: 'Services',
+      home: 'Home',
+      viewService: 'View service',
+      seeAll: 'View all services',
+      scopeTitle: 'What it covers',
+      deliverablesTitle: 'What you receive',
+      faqTitle: 'Frequently asked questions',
+      casesTitle: 'Case studies in this line',
+      casesLead: 'Work delivered on the plant floor within this service.',
+      relatedTitle: 'Other service lines',
+      ctaTitle: 'Have a project like this?',
+      ctaLead: 'Tell us what you need to solve and we will come back with a clear route for your plant.',
+      ctaButton: 'Get a quote',
+    },
     servicios: {
       kick: 'What we do',
       h2Html: 'From the sensor <em>to the management KPI.</em>',
       lead: 'Automation, instrumentation, energy efficiency, component supply and electronic surveillance: we cover the whole chain, from the component and the electrical panel to the management KPI leadership sees.',
-      items: [
-        {
-          title: 'Industrial Automation & Control',
-          desc: 'Control architecture, PLC programming, HMI/SCADA, batch control, MES/MOM and industrial networking. Controller migration, commissioning (FAT/SAT), MCC panels and operator consoles.',
-          tags: ['Allen Bradley', 'Siemens', 'SCADA', 'MIOBOX'],
-        },
-        {
-          title: 'Industrial Instrumentation',
-          desc: 'Instrument selection and implementation, control-loop design and calibration of temperature, pressure, flow and humidity transmitters, with metrological assurance.',
-          tags: ['Control loops', 'Transmitters', 'Metrology'],
-        },
-        {
-          title: 'Energy Efficiency',
-          desc: 'Power-quality analysis, monitoring and telemetering, and energy-saving projects incorporating renewable energy.',
-          tags: ['Power quality', 'Telemetering', 'Renewables'],
-        },
-        {
-          title: 'Electrical Installation',
-          desc: 'Electrical installation design, feasibility studies and industrial and commercial assembly, with maintenance and RETIE code compliance.',
-          tags: ['RETIE', 'Industrial assembly', 'Maintenance'],
-        },
-        {
-          title: 'Mechanical Maintenance',
-          desc: 'Preventive and corrective maintenance, equipment assembly and diagnosis, welding and part fabrication to keep the plant running.',
-          tags: ['Preventive', 'Corrective', 'Welding'],
-        },
-        {
-          title: 'Electrical Panel Design',
-          desc: 'Distribution and automatic transfer panels, capacitor banks (1 to 1520 kvar), PLC/IO integration and variable-speed drives from ½ to 900 HP.',
-          tags: ['Capacitor banks', 'Drives ½–900 HP', 'PLC/IO'],
-        },
-        {
-          title: 'Component Supply & Advisory',
-          desc: 'As a multi-brand distributor, we supply electrical, electronic, automation and specialized parts and components. We add value by advising on their technical selection —sensors, meters, instruments and more— so every component fits the solution.',
-          tags: ['Multi-brand distributor', 'Sensors & meters', 'Technical advisory'],
-        },
-        {
-          title: 'Electronic Surveillance',
-          desc: 'Supply, installation and assembly of electronic surveillance and security systems —CCTV, access control and monitoring— integrated with the plant or facility infrastructure.',
-          tags: ['CCTV', 'Access control', 'Monitoring'],
-        },
-      ],
     },
     nosotros: {
       kick: 'About us',

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -4,6 +4,8 @@
 import '../styles/nocturne.css';
 import ChatWidget from '../components/nocturne/ChatWidget.astro';
 import { ui, getLang, localePath, defaultLang } from '../i18n/ui';
+import { servicios } from '../data/servicios';
+import { imgSize } from '../lib/imageSize';
 
 interface Props {
   title: string;
@@ -70,6 +72,8 @@ const L = (p: string) => localePath(p, lang);
       </>
     )}
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="apple-touch-icon" href="/assets/logo/icono.png" />
+    <link rel="sitemap" type="application/xml" href="/sitemap-index.xml" />
     <meta name="theme-color" content="#0d1417" />
     <meta name="author" content="S&G Soluciones de Ingeniería" />
     {noindex && <meta name="robots" content="noindex, nofollow" />}
@@ -93,10 +97,26 @@ const L = (p: string) => localePath(p, lang);
 
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    {/*
+      La hoja de Google Fonts se carga sin bloquear el render: `media="print"`
+      hace que el navegador la baje con baja prioridad y no espere por ella para
+      pintar, y el onload la promueve a `all` en cuanto llegó. Como las familias
+      se declaran con `display=swap`, el texto se ve desde el primer frame con la
+      fuente de sistema y se recompone al llegar Barlow. Esto quita a la fuente
+      del camino crítico del LCP. El <noscript> cubre a quien tenga JS apagado.
+    */}
     <link
       href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@500;600;700&display=swap"
       rel="stylesheet"
+      media="print"
+      onload="this.media='all';this.onload=null;"
     />
+    <noscript>
+      <link
+        href="https://fonts.googleapis.com/css2?family=Barlow:wght@400;500;600&family=Barlow+Condensed:wght@500;600;700&display=swap"
+        rel="stylesheet"
+      />
+    </noscript>
 
     <!-- Detección de idioma + memoria de preferencia (sólo redirige en el home).
          Nota SEO: el auto-redirect por idioma del navegador es una elección de
@@ -134,7 +154,7 @@ const L = (p: string) => localePath(p, lang);
   <body id="top">
     <nav class="nav" id="nav">
       <a class="brand" href={L('/#top')} aria-label="S&amp;G Soluciones de Ingeniería">
-        <img class="mark" src="/assets/logo/icono.png" alt="" />
+        <img class="mark" src="/assets/logo/icono.png" alt="" {...imgSize("/assets/logo/icono.png")} />
         <span class="bt"><span class="n">S&amp;G</span><span class="d">{tr.nav.tagline}</span></span>
       </a>
       <button class="nav-toggle" aria-label={tr.nav.openMenu} aria-expanded="false" aria-controls="nav-menu">
@@ -144,8 +164,8 @@ const L = (p: string) => localePath(p, lang);
       </button>
       <div id="nav-menu">
         <div class="links">
-          <a href={L('/#servicios')}>{tr.nav.services}</a>
-          <a href={L('/#casos')}>{tr.nav.cases}</a>
+          <a href={L('/servicios')}>{tr.nav.services}</a>
+          <a href={L('/proyectos')}>{tr.nav.cases}</a>
           <a href={L('/#nosotros')}>{tr.nav.about}</a>
           <a href={L('/#contacto')}>{tr.nav.contact}</a>
         </div>
@@ -160,8 +180,44 @@ const L = (p: string) => localePath(p, lang);
 
     <footer class="site">
       <div class="wrap">
-        <span class="brand"><img class="mark" src="/assets/logo/icono.png" alt="" /><span class="n">S&amp;G Soluciones de Ingeniería</span></span>
-        <span>{tr.footer.copyright}</span>
+        <div class="fcols">
+          <div class="fcol fcol-brand">
+            <span class="brand"><img class="mark" src="/assets/logo/icono.png" alt="" {...imgSize("/assets/logo/icono.png")} /><span class="n">S&amp;G Soluciones de Ingeniería</span></span>
+            <p class="fblurb">{tr.footer.blurb}</p>
+          </div>
+
+          <nav class="fcol" aria-label={tr.footer.servicesTitle}>
+            <p class="ftitle">{tr.footer.servicesTitle}</p>
+            <ul>
+              {servicios.map((s) => (
+                <li><a href={L(`/servicios/${s.slug}`)}>{s[lang].title}</a></li>
+              ))}
+            </ul>
+          </nav>
+
+          <nav class="fcol" aria-label={tr.footer.companyTitle}>
+            <p class="ftitle">{tr.footer.companyTitle}</p>
+            <ul>
+              <li><a href={L('/servicios')}>{tr.nav.services}</a></li>
+              <li><a href={L('/proyectos')}>{tr.footer.linkCases}</a></li>
+              <li><a href={L('/#nosotros')}>{tr.footer.linkAbout}</a></li>
+              <li><a href={L('/#contacto')}>{tr.footer.linkContact}</a></li>
+            </ul>
+          </nav>
+
+          <div class="fcol">
+            <p class="ftitle">{tr.footer.contactTitle}</p>
+            <ul class="fcontact">
+              <li><a href="tel:+573243025107">+57 324 302 5107</a></li>
+              <li><a href="mailto:comercial.proyectos@sgsolucionesing.com">comercial.proyectos@sgsolucionesing.com</a></li>
+              <li><span class="lb">{tr.footer.addressLabel}</span> Carrera 44 #69-80, Barranquilla, Colombia</li>
+              <li><span class="lb">{tr.footer.hoursLabel}</span> {tr.footer.hours}</li>
+            </ul>
+          </div>
+        </div>
+        <div class="fbottom">
+          <span>{tr.footer.copyright}</span>
+        </div>
       </div>
     </footer>
 

--- a/src/lib/imageSize.ts
+++ b/src/lib/imageSize.ts
@@ -1,0 +1,132 @@
+// src/lib/imageSize.ts
+// Lee las dimensiones intrínsecas de una imagen servida desde /public.
+//
+// Por qué existe: las imágenes del sitio viven en `public/` y se referencian con
+// rutas absolutas, así que no pasan por `astro:assets` y Astro no puede inferir
+// su tamaño. Sin `width`/`height` en el <img>, el navegador no sabe cuánto
+// espacio reservar y el layout salta cuando la imagen llega — eso es CLS, y CLS
+// es una de las tres Core Web Vitals que Google usa como señal de ranking.
+//
+// Se parsean las cabeceras a mano en lugar de usar `sharp` porque sharp llega
+// como dependencia transitiva de Astro, no declarada en package.json: apoyarse
+// en ella haría que el build dependa de un paquete que nadie prometió mantener
+// ahí. JPEG, PNG, WebP y SVG cubren todo lo que el sitio publica hoy.
+//
+// Sólo corre en build (las páginas son prerenderizadas), así que leer del disco
+// no tiene costo en tiempo de respuesta.
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+export interface ImageSize {
+  width: number;
+  height: number;
+}
+
+// El resultado se memoiza: el mismo logo aparece en muchas páginas y el archivo
+// no cambia durante un build.
+const cache = new Map<string, ImageSize | null>();
+
+function parsePng(buf: Buffer): ImageSize | null {
+  // Firma PNG + chunk IHDR: ancho y alto son enteros de 32 bits big-endian.
+  if (buf.length < 24) return null;
+  if (buf.readUInt32BE(0) !== 0x89504e47) return null;
+  return { width: buf.readUInt32BE(16), height: buf.readUInt32BE(20) };
+}
+
+function parseJpeg(buf: Buffer): ImageSize | null {
+  if (buf.length < 4 || buf[0] !== 0xff || buf[1] !== 0xd8) return null;
+  let offset = 2;
+  while (offset < buf.length - 9) {
+    if (buf[offset] !== 0xff) {
+      offset++;
+      continue;
+    }
+    const marker = buf[offset + 1];
+    // SOF0..SOF15 llevan las dimensiones; se excluyen DHT (c4), JPG (c8) y DAC (cc),
+    // que comparten rango pero no son marcadores de trama.
+    const isSof =
+      marker >= 0xc0 && marker <= 0xcf && marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc;
+    if (isSof) {
+      return { height: buf.readUInt16BE(offset + 5), width: buf.readUInt16BE(offset + 7) };
+    }
+    const segmentLength = buf.readUInt16BE(offset + 2);
+    if (segmentLength < 2) return null;
+    offset += 2 + segmentLength;
+  }
+  return null;
+}
+
+function parseWebp(buf: Buffer): ImageSize | null {
+  if (buf.length < 30) return null;
+  if (buf.toString('ascii', 0, 4) !== 'RIFF' || buf.toString('ascii', 8, 12) !== 'WEBP') return null;
+  const format = buf.toString('ascii', 12, 16);
+  if (format === 'VP8 ') {
+    return { width: buf.readUInt16LE(26) & 0x3fff, height: buf.readUInt16LE(28) & 0x3fff };
+  }
+  if (format === 'VP8L') {
+    const bits = buf.readUInt32LE(21);
+    return { width: (bits & 0x3fff) + 1, height: ((bits >> 14) & 0x3fff) + 1 };
+  }
+  if (format === 'VP8X') {
+    const w = buf[24] | (buf[25] << 8) | (buf[26] << 16);
+    const h = buf[27] | (buf[28] << 8) | (buf[29] << 16);
+    return { width: w + 1, height: h + 1 };
+  }
+  return null;
+}
+
+function parseSvg(buf: Buffer): ImageSize | null {
+  // Sólo se leen los primeros 2 KB: el <svg> raíz siempre está ahí.
+  const head = buf.toString('utf8', 0, Math.min(buf.length, 2048));
+  const viewBox = head.match(/viewBox\s*=\s*["']\s*[\d.-]+[\s,]+[\d.-]+[\s,]+([\d.]+)[\s,]+([\d.]+)/i);
+  if (viewBox) {
+    return { width: Math.round(Number(viewBox[1])), height: Math.round(Number(viewBox[2])) };
+  }
+  // El delimitador tiene que ser inicio o espacio, no `\b`: en `stroke-width`
+  // el guion es un carácter no-palabra, así que `\bwidth` casaría con él y
+  // devolvería el grosor del trazo como ancho de la imagen. El número exige al
+  // menos un dígito, para que un `width="."` no produzca NaN.
+  const NUM = String.raw`\d+(?:\.\d+)?`;
+  const w = head.match(new RegExp(`(?:^|\\s)width\\s*=\\s*["'](${NUM})`, 'i'));
+  const h = head.match(new RegExp(`(?:^|\\s)height\\s*=\\s*["'](${NUM})`, 'i'));
+  if (!w || !h) return null;
+  const width = Math.round(Number(w[1]));
+  const height = Math.round(Number(h[1]));
+  // Un 0 no describe nada y produciría un aspect-ratio inválido en el <img>.
+  return width > 0 && height > 0 ? { width, height } : null;
+}
+
+/**
+ * Dimensiones intrínsecas de una imagen de /public, o `null` si la ruta no es
+ * local, el archivo no existe o el formato no se reconoce. Nunca lanza: una
+ * imagen sin medir debe degradar a un <img> sin atributos, no romper el build.
+ */
+export function getImageSize(src: string | undefined): ImageSize | null {
+  if (!src || !src.startsWith('/') || src.startsWith('//')) return null;
+  if (cache.has(src)) return cache.get(src)!;
+
+  let size: ImageSize | null = null;
+  try {
+    // `src` viene de rutas absolutas del sitio; se resuelven contra public/.
+    const path = join(process.cwd(), 'public', decodeURIComponent(src));
+    const buf = readFileSync(path);
+    size =
+      parsePng(buf) ?? parseJpeg(buf) ?? parseWebp(buf) ?? parseSvg(buf) ?? null;
+  } catch {
+    size = null;
+  }
+
+  cache.set(src, size);
+  return size;
+}
+
+/**
+ * Atributos listos para hacer spread sobre un <img>: `{...imgSize(src)}`.
+ * Devuelve un objeto vacío cuando no se pudo medir, de modo que el markup
+ * quede exactamente como estaba antes.
+ */
+export function imgSize(src: string | undefined): Record<string, number> {
+  const size = getImageSize(src);
+  return size ? { width: size.width, height: size.height } : {};
+}

--- a/src/pages/contacto.astro
+++ b/src/pages/contacto.astro
@@ -2,23 +2,25 @@
 // src/pages/contacto.astro — Rediseño "Nocturne" (Fase 3)
 import BaseLayout from '../layouts/BaseLayout.astro';
 import Contacto from '../components/nocturne/Contacto.astro';
+import { pageTitle } from '../i18n/ui';
+import { imgSize } from '../lib/imageSize';
 
-const pageTitle = 'Contacto | S&G Soluciones de Ingeniería';
+const docTitle = pageTitle('Contacto en Barranquilla');
 const pageDescription =
   'Ponte en contacto con nuestro equipo de expertos en soluciones de ingeniería, automatización industrial y desarrollo de software.';
 ---
 
-<BaseLayout title={pageTitle} description={pageDescription} image="/assets/img/pruebas-1.jpg">
+<BaseLayout title={docTitle} description={pageDescription} image="/assets/img/pruebas-1.jpg">
   <script type="application/ld+json" slot="head" set:html={JSON.stringify({
     '@context': 'https://schema.org',
     '@type': 'ContactPage',
-    name: pageTitle,
+    name: docTitle,
     description: pageDescription,
     url: 'https://www.sgsolucionesing.com/contacto',
   })} />
 
   <header class="phead">
-    <div class="bg"><img src="/assets/img/pruebas-1.jpg" alt="" aria-hidden="true" fetchpriority="high" /></div>
+    <div class="bg"><img src="/assets/img/pruebas-1.jpg" alt="" aria-hidden="true" fetchpriority="high" {...imgSize("/assets/img/pruebas-1.jpg")} /></div>
     <div class="wrap">
       <span class="kick rv in">Contacto</span>
       <h1 class="rv in d1">Hablemos de <em>tu proceso.</em></h1>

--- a/src/pages/en/servicios/[slug].astro
+++ b/src/pages/en/servicios/[slug].astro
@@ -1,0 +1,28 @@
+---
+// src/pages/en/servicios/[slug].astro — Service detail (EN). Body lives in PageServicio.
+import { getCollection } from 'astro:content';
+import PageServicio from '../../../components/PageServicio.astro';
+import { servicios } from '../../../data/servicios';
+
+export async function getStaticPaths() {
+  // English cases live under the en/ subdirectory of the collection.
+  const proyectos = await getCollection('proyectos', (e) => e.id.startsWith('en/'));
+  const bySlug = new Map(
+    proyectos.map((e) => [
+      (e.slug || e.id.split('/').pop()?.replace(/\.mdx?$/, ''))?.replace(/^en\//, ''),
+      e,
+    ])
+  );
+
+  return servicios.map((servicio) => ({
+    params: { slug: servicio.slug },
+    props: {
+      servicio,
+      casos: servicio.casos.map((s) => bySlug.get(s)).filter(Boolean),
+    },
+  }));
+}
+
+const { servicio, casos } = Astro.props;
+---
+<PageServicio servicio={servicio} casos={casos} />

--- a/src/pages/en/servicios/index.astro
+++ b/src/pages/en/servicios/index.astro
@@ -1,0 +1,5 @@
+---
+// src/pages/en/servicios/index.astro — Services hub (EN). Body lives in PageServicios.
+import PageServicios from '../../../components/PageServicios.astro';
+---
+<PageServicios />

--- a/src/pages/servicios/[slug].astro
+++ b/src/pages/servicios/[slug].astro
@@ -1,0 +1,27 @@
+---
+// src/pages/servicios/[slug].astro — Detalle de servicio (ES). Cuerpo en PageServicio.
+import { getCollection } from 'astro:content';
+import PageServicio from '../../components/PageServicio.astro';
+import { servicios } from '../../data/servicios';
+
+export async function getStaticPaths() {
+  // Casos en español: los que NO viven bajo el subdirectorio en/.
+  const proyectos = await getCollection('proyectos', (e) => !e.id.startsWith('en/'));
+  const bySlug = new Map(
+    proyectos.map((e) => [e.slug || e.id.split('/').pop()?.replace(/\.mdx?$/, ''), e])
+  );
+
+  return servicios.map((servicio) => ({
+    params: { slug: servicio.slug },
+    props: {
+      servicio,
+      // Un slug que no resuelve se descarta en lugar de romper el build: la
+      // sección de casos simplemente muestra los que sí existen.
+      casos: servicio.casos.map((s) => bySlug.get(s)).filter(Boolean),
+    },
+  }));
+}
+
+const { servicio, casos } = Astro.props;
+---
+<PageServicio servicio={servicio} casos={casos} />

--- a/src/pages/servicios/index.astro
+++ b/src/pages/servicios/index.astro
@@ -1,0 +1,5 @@
+---
+// src/pages/servicios/index.astro — Hub de servicios (ES). Cuerpo en PageServicios.
+import PageServicios from '../../components/PageServicios.astro';
+---
+<PageServicios />

--- a/src/styles/nocturne.css
+++ b/src/styles/nocturne.css
@@ -170,8 +170,21 @@ h1,h2,h3,h4{font-family:var(--cond);font-weight:600;margin:0;letter-spacing:-0.0
 .form-msg{margin:14px 0 0;font-size:14px;line-height:1.5;min-height:1.2em}
 .form-msg.ok{color:var(--teal-300)}
 .form-msg.error{color:#ff9c8a}
-footer.site{background:#090e10;color:rgba(226,236,236,.6);padding:40px 0}
-footer.site .wrap{display:flex;justify-content:space-between;gap:20px;flex-wrap:wrap;align-items:center;font-size:13.5px}
+footer.site{background:#090e10;color:rgba(226,236,236,.6);padding:56px 0 34px}
+footer.site .wrap{font-size:13.5px}
+/* Cuatro columnas: marca + servicios + empresa + contacto. Los enlaces del pie
+   son el enlazado interno que aparece en TODAS las páginas del sitio. */
+footer.site .fcols{display:grid;grid-template-columns:1.4fr 1fr 1fr 1.2fr;gap:40px 32px;align-items:start}
+footer.site .fcol ul{list-style:none;margin:0;padding:0;display:grid;gap:9px}
+footer.site .ftitle{font-family:var(--cond);font-weight:600;font-size:13px;letter-spacing:.14em;text-transform:uppercase;color:var(--teal-300);margin:0 0 16px}
+footer.site .fcol a{color:rgba(226,236,236,.72);line-height:1.45;transition:color .18s}
+footer.site .fcol a:hover{color:#fff}
+footer.site .fblurb{margin:16px 0 0;line-height:1.6;max-width:38ch;color:rgba(226,236,236,.55)}
+footer.site .fcontact li{line-height:1.5;color:rgba(226,236,236,.72)}
+footer.site .fcontact .lb{display:block;font-family:var(--cond);font-weight:600;font-size:11.5px;letter-spacing:.1em;text-transform:uppercase;color:rgba(226,236,236,.42);margin-bottom:2px}
+footer.site .fbottom{margin-top:44px;padding-top:22px;border-top:1px solid rgba(255,255,255,.1);display:flex;justify-content:space-between;gap:16px;flex-wrap:wrap}
+@media(max-width:1024px){footer.site .fcols{grid-template-columns:1fr 1fr}}
+@media(max-width:620px){footer.site .fcols{grid-template-columns:1fr;gap:34px}}
 footer.site .brand{display:flex;align-items:center;gap:10px;color:#fff}
 footer.site .mark{height:32px;width:auto;display:block}
 footer.site .brand .n{font-family:var(--cond);font-weight:700;letter-spacing:.03em;text-transform:uppercase;font-size:16px}
@@ -336,3 +349,84 @@ footer.site .brand .n{font-family:var(--cond);font-weight:700;letter-spacing:.03
 /* Tarjeta con sello oficial (imagen): el badge reemplaza al ícono+título. */
 .cert--img{align-items:center}
 .cert-badge{flex:none;width:auto;height:auto;max-height:62px;max-width:180px;object-fit:contain}
+
+/* ── Páginas de servicio ─────────────────────────────────────────────────────
+   Todo lo de esta sección va prefijado con .svc-* o scopeado bajo .sec.alt para
+   no pisar el listado de proyectos (.cases) ni las tarjetas del home (.casos),
+   que ya chocaron una vez por compartir nombre de clase. */
+
+/* Enlace "Ver servicio" al pie de cada tarjeta del grid. */
+.svc-link{display:inline-block;margin-top:20px;font-family:var(--cond);font-weight:600;font-size:14px;letter-spacing:.08em;text-transform:uppercase;color:var(--teal-700);border-bottom:1.5px solid var(--teal);padding-bottom:2px;transition:color .18s,border-color .18s}
+.svc-link:hover{color:var(--ink);border-color:var(--ink)}
+.svc h3 a,.svc h2 a{color:inherit;text-decoration:none}
+.svc h3 a:hover,.svc h2 a:hover{color:var(--teal-700)}
+/* En el hub las tarjetas encabezan con h2, porque el h1 es el título de la página. */
+.svc h2{font-size:26px;text-transform:uppercase;margin:6px 0 12px}
+
+.svc-all{margin-top:36px;display:flex;justify-content:center}
+.btn-ghost{display:inline-flex;align-items:center;height:50px;padding:0 28px;border:1.5px solid var(--ink);color:var(--ink);font-family:var(--cond);font-weight:600;font-size:17px;letter-spacing:.03em;text-transform:uppercase;transition:.18s}
+.btn-ghost:hover{border-color:var(--teal);color:var(--teal-700)}
+
+/* Banda alterna, para separar bloques largos dentro del detalle. */
+.sec.alt{background:var(--paper-2)}
+/* Un servicio sin casos publicados deja dos bandas alternas pegadas (p. ej.
+   vigilancia-electronica): sin esta línea se leen como un único bloque tintado
+   del doble de alto. */
+.sec.alt+.sec.alt{border-top:1px solid var(--line)}
+
+/* Párrafo de entrada de una sección del detalle. No se reutiliza `.lead`
+   porque esa clase sólo está definida bajo `.sec-head` y `.certs`, así que
+   aquí caería sin estilo. */
+.svc-lead{font-size:16.5px;line-height:1.6;color:var(--muted);max-width:60ch;margin:-14px 0 0}
+
+.svc-h2{font-size:clamp(28px,3.2vw,44px);line-height:1;text-transform:uppercase;margin:0 0 clamp(28px,3vw,44px)}
+
+/* Qué incluye */
+.svc-scope{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:18px}
+.scope-item{background:#fff;border:1px solid var(--line);padding:28px 26px;border-left:3px solid var(--teal)}
+.scope-item h3{font-size:19px;text-transform:uppercase;margin:0 0 10px;letter-spacing:.01em}
+.scope-item p{font-size:15.5px;line-height:1.6;color:var(--muted);margin:0}
+
+/* Qué recibes */
+.svc-deliver{list-style:none;margin:0;padding:0;display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:14px 32px}
+.svc-deliver li{position:relative;padding-left:28px;font-size:16px;line-height:1.6;color:var(--muted)}
+.svc-deliver li::before{content:"";position:absolute;left:0;top:.62em;width:14px;height:2px;background:var(--teal)}
+
+/* Casos de esta línea */
+.svc-cases{display:grid;grid-template-columns:repeat(3,minmax(0,1fr));gap:20px;margin-top:32px}
+.svc-case{display:block;background:#fff;border:1px solid var(--line);color:inherit;text-decoration:none;overflow:hidden;transition:transform .22s,box-shadow .22s,border-color .22s}
+.svc-case:hover{transform:translateY(-4px);box-shadow:0 22px 44px rgba(13,20,23,.1);border-color:transparent}
+.svc-case .ph{margin:0;overflow:hidden}
+.svc-case .ph img{width:100%;height:auto;aspect-ratio:4/3;object-fit:cover;display:block;transition:transform .4s}
+.svc-case:hover .ph img{transform:scale(1.04)}
+.svc-case .tx{padding:22px 22px 26px}
+.svc-case .sector{font-family:var(--cond);font-weight:600;font-size:12.5px;letter-spacing:.08em;text-transform:uppercase;color:var(--teal-700)}
+.svc-case h3{font-size:19px;text-transform:uppercase;line-height:1.15;margin:8px 0 10px}
+.svc-case p{font-size:14.5px;line-height:1.55;color:var(--muted);margin:0}
+
+/* Preguntas frecuentes */
+.svc-faq{display:grid;gap:16px;max-width:80ch}
+.faq-item{background:#fff;border:1px solid var(--line);padding:26px 26px 24px}
+.faq-item h3{font-size:18.5px;line-height:1.3;margin:0 0 10px;text-transform:none;letter-spacing:0}
+.faq-item p{font-size:15.5px;line-height:1.65;color:var(--muted);margin:0}
+
+/* Otras líneas de servicio */
+.svc-related{list-style:none;margin:0;padding:0;display:flex;flex-wrap:wrap;gap:10px}
+.svc-related a{display:inline-flex;align-items:center;height:42px;padding:0 18px;border:1px solid var(--line);background:#fff;font-family:var(--cond);font-weight:600;font-size:14px;letter-spacing:.05em;text-transform:uppercase;color:var(--ink);transition:.18s}
+.svc-related a:hover{border-color:var(--teal);color:var(--teal-700)}
+
+/* Cierre con llamado a la acción */
+.svc-cta{background:var(--ink);color:#fff;padding:clamp(64px,7vw,104px) 0;text-align:center}
+.svc-cta h2{font-size:clamp(30px,3.6vw,48px);line-height:1;text-transform:uppercase;margin:0}
+.svc-cta p{font-size:16.5px;line-height:1.6;color:#aeb8ba;max-width:52ch;margin:18px auto 0}
+.svc-cta .cta{display:inline-flex;align-items:center;height:52px;padding:0 30px;margin-top:30px;background:var(--teal-700);color:#fff;font-family:var(--cond);font-weight:600;font-size:17px;letter-spacing:.04em;text-transform:uppercase;transition:background .18s,transform .18s}
+.svc-cta .cta:hover{background:var(--teal);transform:translateY(-2px)}
+
+@media (max-width:900px){
+  .svc-scope{grid-template-columns:1fr}
+  .svc-deliver{grid-template-columns:1fr}
+  .svc-cases{grid-template-columns:1fr}
+}
+@media (min-width:901px) and (max-width:1180px){
+  .svc-cases{grid-template-columns:repeat(2,minmax(0,1fr))}
+}


### PR DESCRIPTION
## Por qué

El SEO técnico del sitio ya estaba bien resuelto —canonical, OG/Twitter, hreflang recíproco con `x-default`, JSON-LD en las cuatro plantillas, sitemap, `robots.txt`, un solo `<h1>` por página—. El techo real estaba en otro lado: **las ocho líneas de servicio vivían como tarjetas dentro de `/#servicios`, sin URL propia**. Una sola página compitiendo por ocho términos distintos, con 60 palabras por servicio enterradas en el home.

## Qué cambia

### Arquitectura de contenido

- `src/data/servicios.ts` es ahora la **fuente única bilingüe** de las ocho líneas: meta, `h1`, lead, alcance, entregables, FAQ y los casos que las ejemplifican. Alimenta el home, el hub, cada detalle y el `hasOfferCatalog` del JSON-LD, así que no pueden divergir. Se eliminó `ui.servicios.items` para no dejar dos fuentes.
- **18 rutas nuevas**: `/servicios`, `/servicios/<slug>` ×8 y sus equivalentes bajo `/en/`. Cada detalle lleva JSON-LD `Service` + `FAQPage` + `BreadcrumbList`; el hub lleva `ItemList`. **Sitemap: 39 → 57 URLs.**
- Cada servicio enlaza los casos reales de la colección `proyectos`. Un servicio sin casos publicados (`vigilancia-electronica`) simplemente no renderiza la sección, en vez de mostrar trabajo que no le corresponde.

### Enlazado interno

- El nav pasa de anclas del home (`/#servicios`, `/#casos`) a las páginas reales, y el footer pasa a cuatro columnas con las ocho líneas. Resultado: **cada página del sitio enlaza a las ocho páginas de servicio**.

### SEO local

- Se completa el JSON-LD de la organización con `geo`, `openingHoursSpecification`, `hasMap` y `hasOfferCatalog`. Las coordenadas salen del mapa que ya estaba embebido en `/contacto`, no son inventadas.
- **`sameAs` queda fuera a propósito**: no hay perfiles sociales confirmados, y declarar uno equivocado es peor que no declarar ninguno.

### Core Web Vitals

- `src/lib/imageSize.ts` lee las dimensiones intrínsecas parseando las cabeceras PNG/JPEG/WebP/SVG, **sin dependencias**. Las imágenes viven en `public/` y no pasan por `astro:assets`, así que Astro no puede inferirlas y el layout saltaba al cargar (CLS). Se evitó `sharp` a propósito: llega como transitiva de Astro y no está declarada en `package.json`.
- Imágenes sin dimensiones: **223 → 36** (las restantes se inyectan por JS y no son medibles en build).
- La hoja de Google Fonts deja de bloquear el render.

### Títulos

- `pageTitle()` agrega la marca solo mientras entre en el presupuesto de ~60 caracteres del SERP. El sufijo completo se comía 31 de esos, así que **casi todo el sitio aparecía truncado en Google**.

## Verificación

- `astro build` limpio.
- Auditoría propia sobre las **57 páginas compiladas** —`h1` único, largos de `title`/`description`, canonical, JSON-LD parseable, `alt` y dimensiones—: **de 58 hallazgos a 0**.
- Revisión de fiabilidad sobre los 27 archivos: sin defectos severos. Los cuatro hallazgos menores que sí encontró están corregidos en esta rama (`.lead` sin regla CSS que lo matcheara, bandas alternas adyacentes cuando un servicio no tiene casos, cuatro `metaDescription` sobre el tope de 160, y la regex del fallback SVG que matcheaba `stroke-width`).
- Screenshots desktop y mobile del hub y de un detalle: sin errores de consola ni desbordes horizontales.

## Fuera de alcance, pero conviene saberlo

**El dominio sin `www` devuelve 404.** `sgsolucionesing.com` responde `HTTP 404` desde Cloudflare mientras `www.sgsolucionesing.com` responde `200`. El DNS y el proxy están bien —ambos resuelven a las mismas IPs—, pero solo el hostname `www` está enrutado al origen. Esto (a) hace que **la verificación de AdSense falle**, porque verifica el apex y ahí `ads.txt` da 404, y (b) pierde la autoridad de cualquier backlink al apex. Se arregla con una Redirect Rule 301 en Cloudflare del apex a `www`, preservando path y querystring. Es configuración de infraestructura, no entra en este PR.

## Pendientes

- `sameAs` con los perfiles sociales reales (falta el dato).
- WebP/AVIF: sigue todo en JPG/PNG. Migrar a `astro:assets` es invasivo porque las imágenes viven en `public/`.
- Search Console: es lo que corresponde para indexación, y hoy no está configurado.
